### PR TITLE
Xbox fix

### DIFF
--- a/src-tauri/src/firmware/flash.rs
+++ b/src-tauri/src/firmware/flash.rs
@@ -238,7 +238,7 @@ fn open_device(device: &str) -> Result<DeviceHandle, String> {
   let drive_handle = open_physical_drive_with_retries(device)?;
 
   let raw = drive_handle.0;
-  let file = unsafe { std::fs::File::from_raw_handle(raw as _) };
+  let file = unsafe { std::fs::File::from_raw_handle(raw.cast()) };
   Ok(DeviceHandle {
     file,
     _volume_handles: volume_handles,
@@ -495,7 +495,7 @@ fn flush_device_to_media(file: &std::fs::File) -> Result<(), String> {
   use windows::Win32::Foundation::HANDLE;
   use windows::Win32::Storage::FileSystem::FlushFileBuffers;
 
-  let handle = HANDLE(file.as_raw_handle() as _);
+  let handle = HANDLE(file.as_raw_handle().cast());
   unsafe { FlushFileBuffers(handle) }.map_err(|e| format!("FlushFileBuffers failed: {e}"))
 }
 

--- a/src-tauri/src/gamepad.rs
+++ b/src-tauri/src/gamepad.rs
@@ -66,6 +66,10 @@ fn run_gamepad_stream<R: Runtime>(
   app: &AppHandle<R>,
   rx: &mpsc::Receiver<VibrateCommand>,
 ) -> Result<(), String> {
+  // This background stream has no SDL window, so use XInput instead of
+  // Windows RawInput for Xbox controllers.
+  sdl2::hint::set("SDL_JOYSTICK_RAWINPUT", "0");
+
   let sdl = sdl2::init()?;
   let controller_subsystem = sdl.game_controller()?;
   let joystick_subsystem = sdl.joystick()?;


### PR DESCRIPTION
## Summary
One-line change to change the protocol used for communicating with xbox controllers.

## Platform Testing
Tested on windows 10 with xbox controller. Controller was not able to connect before change, but was able to connect flawlessly after change.

- [ ] macOS
- [x] Windows
- [ ] Linux

- **Potential platform issues:** [Known differences or concerns for specific OS]
None

## Checklist

- [x] Code compiles (`bun run tauri build`)
- [x] Tested manually
- [x] No breaking changes to firmware communication


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved controller handling in background or headless streaming, especially for Xbox controllers on Windows.
  * Reduced issues caused by an alternate input backend so gamepad input behaves more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->