### PR TITLE
ci: add stable required check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
   pull_request:
+
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -79,3 +83,19 @@ jobs:
         run: cargo test
       - name: Build
         run: cargo build --all-targets --all-features
+
+  ci:
+    name: ci
+    if: always()
+    needs:
+      - check-frontend
+      - check-backend
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require all checks
+        env:
+          FRONTEND_RESULT: ${{ needs.check-frontend.result }}
+          BACKEND_RESULT: ${{ needs.check-backend.result }}
+        run: |
+          test "$FRONTEND_RESULT" = success
+          test "$BACKEND_RESULT" = success


### PR DESCRIPTION
## Summary

- set read-only default workflow permissions
- add a stable `ci` job that aggregates frontend and backend validation
- provide one durable status context for the shared branch ruleset

## Validation

- frontend production build
- 36 Vitest tests
- oxlint and oxfmt
- Rust formatting and Clippy
- 16 Rust tests
- Rust all-target/all-feature build
- actionlint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved continuous integration reliability by enforcing that the overall check fails when either frontend or backend validation fails.
  * Added read-only repository access for automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->