### PR TITLE
fix(connection): follow ROV address changes

### DIFF
--- a/messages/en-gb.json
+++ b/messages/en-gb.json
@@ -498,6 +498,7 @@
   "toasts_rov_config_import_not_object": "Selected file is not a configuration object",
   "toasts_rov_config_imported_partial": "Imported with {count} skipped fields: {fields}",
   "toasts_rov_ip_address_changing": "IP address changing, you may need to reconnect.",
+  "toasts_rov_connection_restart_failed": "ROV connection saved, but the firmware service could not restart. Reboot the ROV to apply it.",
   "toasts_example_action_triggered": "Example action triggered",
   "toasts_example_action_description": "This is a sample custom action",
   "toasts_cpu_temperature_title": "CPU temperature: {temperature}°C",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -42,7 +42,7 @@ use toast::toast_init;
 use tokio::sync::mpsc::channel;
 
 use websocket::client::{
-  DirectionVectorSendChannelState, MessageSendChannelState, start_websocket_client,
+  DirectionVectorSendChannelState, MessageSendChannelState, OutboundMessage, start_websocket_client,
 };
 use websocket::message::WebsocketMessage;
 
@@ -58,7 +58,7 @@ fn setup_handlers(app: &mut App) {
   let websocket_handle = app.app_handle().clone();
   let (config_tx, config_rx) = channel::<Config>(1);
   app.manage(ConfigSendChannelState { tx: config_tx });
-  let (message_tx, message_rx) = channel::<WebsocketMessage>(1);
+  let (message_tx, message_rx) = channel::<OutboundMessage>(1);
   app.manage(MessageSendChannelState { tx: message_tx });
   let (direction_vector_tx, direction_vector_rx) = channel::<WebsocketMessage>(8);
   app.manage(DirectionVectorSendChannelState {

--- a/src-tauri/src/websocket/client.rs
+++ b/src-tauri/src/websocket/client.rs
@@ -36,6 +36,13 @@ pub struct DirectionVectorSendChannelState {
   pub tx: mpsc::Sender<WebsocketMessage>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum MessageSendOutcome {
+  Sent,
+  SerializationFailed,
+  ConnectionFailed,
+}
+
 fn emit_connection_status(app: &AppHandle, is_connected: bool, delay: Option<u128>) {
   if let Err(error) = app.emit(
     "rov_connection_status_updated",
@@ -84,7 +91,7 @@ async fn send_serialized_message<S>(
   message: &WebsocketMessage,
   serialize_label: &str,
   error_label: &str,
-) -> bool
+) -> MessageSendOutcome
 where
   S: Sink<Message, Error = tungstenite::Error> + Unpin,
 {
@@ -92,11 +99,34 @@ where
     Ok(text) => text,
     Err(error) => {
       log_warn!("Failed to serialize {}: {}", serialize_label, error);
-      return true;
+      return MessageSendOutcome::SerializationFailed;
     },
   };
 
-  send_text_message(write, app, message_text, error_label).await
+  if send_text_message(write, app, message_text, error_label).await {
+    MessageSendOutcome::Sent
+  } else {
+    MessageSendOutcome::ConnectionFailed
+  }
+}
+
+fn complete_outbound_message(
+  completion: Option<oneshot::Sender<Result<(), String>>>,
+  outcome: MessageSendOutcome,
+) -> bool {
+  let result = match outcome {
+    MessageSendOutcome::Sent => Ok(()),
+    MessageSendOutcome::SerializationFailed => {
+      Err("Failed to serialize message for the ROV.".to_string())
+    },
+    MessageSendOutcome::ConnectionFailed => Err("Failed to send message to the ROV.".to_string()),
+  };
+
+  if let Some(completion) = completion {
+    let _ = completion.send(result);
+  }
+
+  outcome == MessageSendOutcome::ConnectionFailed
 }
 
 async fn send_ping<S>(write: &mut S, app: &AppHandle) -> bool
@@ -210,33 +240,25 @@ pub async fn start_websocket_client(
             config = new_config;
           }
           Some(outbound) = message_rx.recv() => {
-              let sent = send_serialized_message(
+              let outcome = send_serialized_message(
                 &mut write,
                 &app,
                 &outbound.message,
                 "message",
                 "",
               ).await;
-              if let Some(completion) = outbound.sent {
-                let result = if sent {
-                  Ok(())
-                } else {
-                  Err("Failed to send message to the ROV.".to_string())
-                };
-                let _ = completion.send(result);
-              }
-              if !sent {
+              if complete_outbound_message(outbound.sent, outcome) {
                 break;
               }
           }
           Some(direction_vector) = direction_vector_rx.recv() => {
-              if !send_serialized_message(
+              if send_serialized_message(
                 &mut write,
                 &app,
                 &direction_vector,
                 "direction vector",
                 " (direction vector)",
-              ).await {
+              ).await == MessageSendOutcome::ConnectionFailed {
                 break;
               }
           }
@@ -265,5 +287,42 @@ async fn wait_before_retry(rx: &mut Receiver<Config>) -> Option<Config> {
           log_info!("3 seconds passed, retrying connection.");
           None
       }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  /// # Panics
+  /// Panics if serialization failure is not returned to the waiting sender.
+  #[tokio::test]
+  async fn serialization_failure_is_reported_without_reconnecting() {
+    let (sent_tx, sent_rx) = oneshot::channel();
+
+    let should_reconnect =
+      complete_outbound_message(Some(sent_tx), MessageSendOutcome::SerializationFailed);
+
+    assert!(!should_reconnect);
+    assert_eq!(
+      sent_rx.await.expect("delivery acknowledgement"),
+      Err("Failed to serialize message for the ROV.".to_string())
+    );
+  }
+
+  /// # Panics
+  /// Panics if a connection failure is not returned to the waiting sender.
+  #[tokio::test]
+  async fn connection_failure_is_reported_and_reconnects() {
+    let (sent_tx, sent_rx) = oneshot::channel();
+
+    let should_reconnect =
+      complete_outbound_message(Some(sent_tx), MessageSendOutcome::ConnectionFailed);
+
+    assert!(should_reconnect);
+    assert_eq!(
+      sent_rx.await.expect("delivery acknowledgement"),
+      Err("Failed to send message to the ROV.".to_string())
+    );
   }
 }

--- a/src-tauri/src/websocket/client.rs
+++ b/src-tauri/src/websocket/client.rs
@@ -2,7 +2,10 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use futures_util::{Sink, SinkExt, StreamExt};
 use tauri::{AppHandle, Emitter};
-use tokio::sync::mpsc::{self, Receiver};
+use tokio::sync::{
+  mpsc::{self, Receiver},
+  oneshot,
+};
 use tokio::time::{interval, sleep, timeout};
 use tokio_tungstenite::connect_async;
 use tokio_tungstenite::tungstenite::{self, Message};
@@ -21,7 +24,12 @@ struct ConnectionStatus {
 }
 
 pub struct MessageSendChannelState {
-  pub tx: mpsc::Sender<WebsocketMessage>,
+  pub tx: mpsc::Sender<OutboundMessage>,
+}
+
+pub struct OutboundMessage {
+  pub message: WebsocketMessage,
+  pub sent: Option<oneshot::Sender<Result<(), String>>>,
 }
 
 pub struct DirectionVectorSendChannelState {
@@ -151,7 +159,7 @@ where
 pub async fn start_websocket_client(
   app: AppHandle,
   mut config_rx: Receiver<Config>,
-  mut message_rx: Receiver<WebsocketMessage>,
+  mut message_rx: Receiver<OutboundMessage>,
   mut direction_vector_rx: Receiver<WebsocketMessage>,
 ) {
   let mut config = get_config_from_file();
@@ -192,15 +200,6 @@ pub async fn start_websocket_client(
 
     loop {
       tokio::select! {
-          // A ROV address update and the matching app retarget arrive on
-          // separate channels. Flush the ROV update to the current socket
-          // before reconnecting to its new address.
-          biased;
-          Some(message_to_send) = message_rx.recv() => {
-              if !send_serialized_message(&mut write, &app, &message_to_send, "message", "").await {
-                break;
-              }
-          }
           Some(new_config) = config_rx.recv() => {
             if config_requires_reconnect(&new_config, &config) {
               log_info!("WebSocket config updated. Reconnecting websocket.");
@@ -209,6 +208,26 @@ pub async fn start_websocket_client(
               break;
             }
             config = new_config;
+          }
+          Some(outbound) = message_rx.recv() => {
+              let sent = send_serialized_message(
+                &mut write,
+                &app,
+                &outbound.message,
+                "message",
+                "",
+              ).await;
+              if let Some(completion) = outbound.sent {
+                let result = if sent {
+                  Ok(())
+                } else {
+                  Err("Failed to send message to the ROV.".to_string())
+                };
+                let _ = completion.send(result);
+              }
+              if !sent {
+                break;
+              }
           }
           Some(direction_vector) = direction_vector_rx.recv() => {
               if !send_serialized_message(

--- a/src-tauri/src/websocket/client.rs
+++ b/src-tauri/src/websocket/client.rs
@@ -192,6 +192,15 @@ pub async fn start_websocket_client(
 
     loop {
       tokio::select! {
+          // A ROV address update and the matching app retarget arrive on
+          // separate channels. Flush the ROV update to the current socket
+          // before reconnecting to its new address.
+          biased;
+          Some(message_to_send) = message_rx.recv() => {
+              if !send_serialized_message(&mut write, &app, &message_to_send, "message", "").await {
+                break;
+              }
+          }
           Some(new_config) = config_rx.recv() => {
             if config_requires_reconnect(&new_config, &config) {
               log_info!("WebSocket config updated. Reconnecting websocket.");
@@ -200,11 +209,6 @@ pub async fn start_websocket_client(
               break;
             }
             config = new_config;
-          }
-          Some(message_to_send) = message_rx.recv() => {
-              if !send_serialized_message(&mut write, &app, &message_to_send, "message", "").await {
-                break;
-              }
           }
           Some(direction_vector) = direction_vector_rx.recv() => {
               if !send_serialized_message(

--- a/src-tauri/src/websocket/send.rs
+++ b/src-tauri/src/websocket/send.rs
@@ -187,6 +187,8 @@ pub async fn handle_flash_mcu_firmware(
 mod tests {
   use super::*;
 
+  /// # Panics
+  /// Panics if the message isn't queued, acknowledged, or completed successfully.
   #[tokio::test]
   async fn send_message_waits_for_websocket_delivery() {
     let (tx, mut rx) = tokio::sync::mpsc::channel(1);
@@ -205,6 +207,8 @@ mod tests {
     assert_eq!(send_task.await.expect("send task"), Ok(()));
   }
 
+  /// # Panics
+  /// Panics if the message isn't queued or the delivery failure isn't propagated.
   #[tokio::test]
   async fn send_message_returns_websocket_delivery_failure() {
     let (tx, mut rx) = tokio::sync::mpsc::channel(1);

--- a/src-tauri/src/websocket/send.rs
+++ b/src-tauri/src/websocket/send.rs
@@ -1,23 +1,56 @@
 use tauri::State;
-use tokio::sync::mpsc::Sender;
+use tokio::sync::{mpsc::Sender, oneshot};
 
 use crate::log_error;
 use crate::models::actions::{CustomAction, DirectionVector};
 use crate::models::rov_config::{McuBoard, PartialRovConfig, ThrusterTest};
-use crate::websocket::client::{DirectionVectorSendChannelState, MessageSendChannelState};
+use crate::websocket::client::{
+  DirectionVectorSendChannelState, MessageSendChannelState, OutboundMessage,
+};
 use crate::websocket::message::WebsocketMessage;
 
 /// # Errors
 /// Returns an error if the websocket send channel is unavailable.
 async fn send_message(
-  tx: &Sender<WebsocketMessage>,
+  tx: &Sender<OutboundMessage>,
   message: WebsocketMessage,
   label: &str,
 ) -> Result<(), String> {
-  tx.send(message).await.map_err(|error| {
+  tx.send(OutboundMessage {
+    message,
+    sent: None,
+  })
+  .await
+  .map_err(|error| {
     log_error!("Failed to send {label}: {error}");
     error.to_string()
   })
+}
+
+/// Queue a message and wait until the active WebSocket has written it.
+///
+/// # Errors
+/// Returns an error if the message cannot be queued or its delivery fails.
+async fn send_message_and_wait(
+  tx: &Sender<OutboundMessage>,
+  message: WebsocketMessage,
+  label: &str,
+) -> Result<(), String> {
+  let (sent_tx, sent_rx) = oneshot::channel();
+  tx.send(OutboundMessage {
+    message,
+    sent: Some(sent_tx),
+  })
+  .await
+  .map_err(|error| {
+    log_error!("Failed to queue {label}: {error}");
+    error.to_string()
+  })?;
+
+  sent_rx.await.map_err(|error| {
+    log_error!("Failed to confirm {label} delivery: {error}");
+    error.to_string()
+  })?
 }
 
 /// # Errors
@@ -26,7 +59,14 @@ pub async fn handle_send_direction_vector(
   state: &State<'_, DirectionVectorSendChannelState>,
   payload: DirectionVector,
 ) -> Result<(), String> {
-  send_message(&state.tx, WebsocketMessage::DirectionVector(payload), "DirectionVector").await
+  state
+    .tx
+    .send(WebsocketMessage::DirectionVector(payload))
+    .await
+    .map_err(|error| {
+      log_error!("Failed to send DirectionVector: {error}");
+      error.to_string()
+    })
 }
 
 /// # Errors
@@ -78,7 +118,7 @@ pub async fn handle_set_rov_config(
   state: &State<'_, MessageSendChannelState>,
   payload: PartialRovConfig,
 ) -> Result<(), String> {
-  send_message(&state.tx, WebsocketMessage::SetConfig(payload), "SetConfig").await
+  send_message_and_wait(&state.tx, WebsocketMessage::SetConfig(payload), "SetConfig").await
 }
 
 /// # Errors
@@ -141,4 +181,44 @@ pub async fn handle_flash_mcu_firmware(
   payload: McuBoard,
 ) -> Result<(), String> {
   send_message(&state.tx, WebsocketMessage::FlashMcuFirmware(payload), "FlashMcuFirmware").await
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[tokio::test]
+  async fn send_message_waits_for_websocket_delivery() {
+    let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+    let send_task = tokio::spawn(async move {
+      send_message_and_wait(&tx, WebsocketMessage::GetConfig, "GetConfig").await
+    });
+
+    let outbound = rx.recv().await.expect("queued websocket message");
+    assert!(!send_task.is_finished());
+    outbound
+      .sent
+      .expect("delivery acknowledgement")
+      .send(Ok(()))
+      .expect("waiting sender");
+
+    assert_eq!(send_task.await.expect("send task"), Ok(()));
+  }
+
+  #[tokio::test]
+  async fn send_message_returns_websocket_delivery_failure() {
+    let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+    let send_task = tokio::spawn(async move {
+      send_message_and_wait(&tx, WebsocketMessage::GetConfig, "GetConfig").await
+    });
+
+    let outbound = rx.recv().await.expect("queued websocket message");
+    outbound
+      .sent
+      .expect("delivery acknowledgement")
+      .send(Err("delivery failed".to_string()))
+      .expect("waiting sender");
+
+    assert_eq!(send_task.await.expect("send task"), Err("delivery failed".to_string()));
+  }
 }

--- a/src/features/settings/forms/RovConnection.tsx
+++ b/src/features/settings/forms/RovConnection.tsx
@@ -10,7 +10,7 @@ import { z } from 'zod';
 
 import * as m from '@/paraglide/messages';
 import { rovConfigStore } from '@/stores/rovConfig';
-import { setRovConfig } from '@/tauri';
+import { updateRovConnection } from '@/tauri';
 
 const MAX_PORT = 65_535;
 
@@ -26,10 +26,7 @@ const formSchema = z.object({
 type RovConnectionFormValues = z.infer<typeof formSchema>;
 
 const submitRovConnectionConfig = (value: RovConnectionFormValues): Promise<void> =>
-  setRovConfig({
-    ipAddress: value.ipAddress,
-    websocketPort: value.websocketPort,
-  });
+  updateRovConnection(value);
 
 type AppFieldContext = {
   NumberInputField: Component<NumberInputFieldProps>;

--- a/src/tauri/index.ts
+++ b/src/tauri/index.ts
@@ -16,6 +16,7 @@ export { setDesiredDepth } from '@/tauri/desiredDepth';
 export { initializeVideoDirectory, recoverTempRecordings, saveRecording } from '@/tauri/recording';
 export { regulatorSuggestions, startRegulatorAutoTuning } from '@/tauri/regulator';
 export { importRovConfig, requestRovConfig, setRovConfig } from '@/tauri/rovConfig';
+export { updateRovConnection } from '@/tauri/rovConnection';
 export {
   cancelFirmwareFlash,
   loadFirmwareVersions,

--- a/src/tauri/rovConnection.test.ts
+++ b/src/tauri/rovConnection.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  setConfig: vi.fn(),
+  setRovConfig: vi.fn(),
+}));
+
+vi.mock('@/tauri/config', () => ({ setConfig: mocks.setConfig }));
+vi.mock('@/tauri/rovConfig', () => ({ setRovConfig: mocks.setRovConfig }));
+
+import { updateRovConnection } from '@/tauri/rovConnection';
+
+describe('updateRovConnection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.setRovConfig.mockImplementation(() => Promise.resolve());
+    mocks.setConfig.mockImplementation(() => Promise.resolve());
+  });
+
+  test('retargets the app after sending the connection change to the ROV', () => {
+    const calls: string[] = [];
+    mocks.setRovConfig.mockImplementation(() => {
+      calls.push('rov');
+      return Promise.resolve();
+    });
+    mocks.setConfig.mockImplementation(() => {
+      calls.push('app');
+      return Promise.resolve();
+    });
+
+    return updateRovConnection({ ipAddress: '10.10.11.10', websocketPort: 9100 }).then(() => {
+      expect(calls).toEqual(['rov', 'app']);
+      expect(mocks.setRovConfig).toHaveBeenCalledWith({
+        ipAddress: '10.10.11.10',
+        websocketPort: 9100,
+      });
+      expect(mocks.setConfig).toHaveBeenCalledWith({
+        ipAddress: '10.10.11.10',
+        webSocketPort: 9100,
+      });
+    });
+  });
+
+  test('keeps the app on the current address if sending to the ROV fails', () => {
+    mocks.setRovConfig.mockRejectedValue(new Error('send failed'));
+
+    return expect(updateRovConnection({ ipAddress: '10.10.11.10', websocketPort: 9100 }))
+      .rejects.toThrow('send failed')
+      .then(() => {
+        expect(mocks.setConfig).not.toHaveBeenCalled();
+      });
+  });
+});

--- a/src/tauri/rovConnection.ts
+++ b/src/tauri/rovConnection.ts
@@ -1,0 +1,15 @@
+import { setConfig } from '@/tauri/config';
+import { setRovConfig } from '@/tauri/rovConfig';
+
+export type RovConnectionConfig = {
+  ipAddress: string;
+  websocketPort: number;
+};
+
+export const updateRovConnection = (connection: RovConnectionConfig): Promise<void> =>
+  setRovConfig(connection).then(() =>
+    setConfig({
+      ipAddress: connection.ipAddress,
+      webSocketPort: connection.websocketPort,
+    }),
+  );


### PR DESCRIPTION
## Summary

- update the app connection target after sending a ROV IP/port change
- wait for an explicit WebSocket delivery acknowledgement before reconnecting
- reconnect WebSocket and video endpoints using the new address
- keep the current app target when sending the ROV update fails

## Why

The ROV connection form previously changed only the firmware configuration. The app continued reconnecting to the old address. Updating the two independent channels without an acknowledgement could also disconnect the current WebSocket before it delivered the ROV change.

## Compatibility and merge order

Companion to firmware PR #76: https://github.com/manafishrov/firmware/pull/76

Merge/release the firmware change first. New firmware restarts its service on the new address; older apps can still be pointed to it manually. This app change then makes that handoff automatic.

## Validation

- `bun run fmt:check`
- `bun run lint`
- `bun run test` (43 passed)
- `bun run build`
- `bun run fmt:rs:check`
- `bun run lint:rs`
- `cargo test --manifest-path src-tauri/Cargo.toml` (23 passed)
