### PR TITLE
fix(frontend): harden settings and prerelease updates

### DIFF
--- a/messages/en-gb.json
+++ b/messages/en-gb.json
@@ -339,8 +339,6 @@
   "power_min_battery_voltage_description": "The voltage of the battery when it is fully depleted. This will show as 0% battery in the app. Leave at default value unless you change to another type of battery.",
   "power_max_battery_voltage_label": "Battery Maximum Voltage",
   "power_max_battery_voltage_description": "The voltage of the battery when it is fully charged. This will show as 100% battery in the app. Leave at default value unless you change to another type of battery.",
-  "power_internal_resistance_label": "Battery Internal Resistance (Ω)",
-  "power_internal_resistance_description": "The internal resistance of the battery in ohms. Used to compensate for voltage sag under load, improving battery percentage accuracy. Set to 0 to disable.",
   "power_high_power_warning_title": "High power can wear out the battery",
   "power_high_power_warning_description": "Setting this above 40% draws more than around 20A from the battery, which significantly reduces the number of useful charge cycles. The Manafish will still work, but the battery will wear out much faster. See the assembly guide for details.",
   "power_high_power_warning_confirm": "Keep high value",

--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -2,21 +2,21 @@ use tauri::{AppHandle, Manager, State, command};
 
 use crate::config::{ConfigSendChannelState, get_config_from_file, set_config_to_file};
 use crate::models::config::Config;
+use crate::models::log::LogEntry;
 
 #[command]
 #[allow(clippy::needless_pass_by_value)]
 /// # Errors
-/// Returns an error if the splashscreen or main window cannot be found or controlled.
+/// Returns an error if the main window cannot be found or controlled.
 pub fn close_splashscreen(app: AppHandle) -> Result<(), String> {
-  let splashscreen = app
-    .get_webview_window("splashscreen")
-    .ok_or_else(|| "Splashscreen window not found".to_string())?;
-  splashscreen.close().map_err(|error| error.to_string())?;
-
   let main_window = app
     .get_webview_window("main")
     .ok_or_else(|| "Main window not found".to_string())?;
   main_window.show().map_err(|error| error.to_string())?;
+
+  if let Some(splashscreen) = app.get_webview_window("splashscreen") {
+    splashscreen.close().map_err(|error| error.to_string())?;
+  }
 
   Ok(())
 }
@@ -24,6 +24,11 @@ pub fn close_splashscreen(app: AppHandle) -> Result<(), String> {
 #[command]
 pub fn get_config() -> Config {
   get_config_from_file()
+}
+
+#[command]
+pub fn initialize_log_listener() -> Vec<LogEntry> {
+  crate::log::initialize_log_listener()
 }
 
 #[command]

--- a/src-tauri/src/commands/app_update.rs
+++ b/src-tauri/src/commands/app_update.rs
@@ -60,6 +60,15 @@ fn version_from_tag(tag: &str) -> &str {
   tag.strip_prefix('v').unwrap_or(tag)
 }
 
+fn manifest_matches_tag(expected: &Version, manifest: &Version) -> bool {
+  manifest == expected
+    || (!expected.pre.is_empty()
+      && manifest.pre.is_empty()
+      && manifest.major == expected.major
+      && manifest.minor == expected.minor
+      && manifest.patch == expected.patch)
+}
+
 /// # Errors
 /// Returns an error if the `GitHub` releases cannot be fetched or parsed.
 #[command]
@@ -141,7 +150,9 @@ pub async fn install_app_release(
     .updater_builder()
     .endpoints(vec![endpoint])
     .map_err(|e| e.to_string())?
-    .version_comparator(move |_current, release| release.version == comparator_expected)
+    .version_comparator(move |_current, release| {
+      manifest_matches_tag(&comparator_expected, &release.version)
+    })
     .build()
     .map_err(|e| e.to_string())?;
 
@@ -170,4 +181,49 @@ pub async fn install_app_release(
     .map_err(|e| e.to_string())?;
 
   Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  /// # Panics
+  /// Panics if stable manifest matching accepts a different version.
+  #[test]
+  fn stable_tags_require_an_exact_manifest_version() {
+    let expected = Version::parse("1.2.3").expect("test version should be valid");
+
+    assert!(manifest_matches_tag(
+      &expected,
+      &Version::parse("1.2.3").expect("test version should be valid")
+    ));
+    assert!(!manifest_matches_tag(
+      &expected,
+      &Version::parse("1.2.4").expect("test version should be valid")
+    ));
+  }
+
+  /// # Panics
+  /// Panics if prerelease tags do not accept the same release's stable manifest version.
+  #[test]
+  fn prerelease_tags_accept_release_builds_with_the_same_core_version() {
+    let expected = Version::parse("1.2.3-rc2").expect("test version should be valid");
+
+    assert!(manifest_matches_tag(
+      &expected,
+      &Version::parse("1.2.3-rc2").expect("test version should be valid")
+    ));
+    assert!(manifest_matches_tag(
+      &expected,
+      &Version::parse("1.2.3").expect("test version should be valid")
+    ));
+    assert!(!manifest_matches_tag(
+      &expected,
+      &Version::parse("1.2.3-rc1").expect("test version should be valid")
+    ));
+    assert!(!manifest_matches_tag(
+      &expected,
+      &Version::parse("1.2.4").expect("test version should be valid")
+    ));
+  }
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -6,7 +6,7 @@ pub mod gamepad;
 pub mod recording;
 pub mod rov;
 
-pub use app::{close_splashscreen, get_config, set_config};
+pub use app::{close_splashscreen, get_config, initialize_log_listener, set_config};
 pub use app_update::{fetch_app_releases, install_app_release};
 pub use control::{
   send_custom_action, send_direction_vector, set_desired_depth, toggle_auto_stabilization,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,9 +27,9 @@ use commands::{
   append_recording_chunk, cancel_flash, cancel_regulator_auto_tuning, cancel_thruster_test,
   cleanup_firmware_cache, close_splashscreen, download_firmware_update, fetch_app_releases,
   fetch_firmware_manifest, flash_mcu_firmware, gamepad_vibrate, get_config, import_rov_config,
-  install_app_release, list_firmware_releases, list_flash_drives, prepare_flash,
-  request_rov_config, save_recording, send_custom_action, send_direction_vector, set_config,
-  set_desired_depth, set_rov_config, signal_flash_image, start_gamepad_stream,
+  initialize_log_listener, install_app_release, list_firmware_releases, list_flash_drives,
+  prepare_flash, request_rov_config, save_recording, send_custom_action, send_direction_vector,
+  set_config, set_desired_depth, set_rov_config, signal_flash_image, start_gamepad_stream,
   start_regulator_auto_tuning, start_thruster_test, toggle_auto_stabilization, toggle_depth_hold,
 };
 use config::ConfigSendChannelState;
@@ -225,6 +225,8 @@ fn setup_bundled_webkit() {
 /// # Errors
 /// Returns an error if the Tauri application cannot be built.
 pub fn run() -> tauri::Result<()> {
+  const SPLASHSCREEN_FALLBACK_SECONDS: u64 = 15;
+
   let raw_args: Vec<String> = std::env::args().collect();
   if raw_args.iter().any(|arg| arg == "--flash") {
     let exit_code = run_flasher_cli(&raw_args);
@@ -261,6 +263,7 @@ pub fn run() -> tauri::Result<()> {
       start_gamepad_stream,
       gamepad_vibrate,
       get_config,
+      initialize_log_listener,
       set_config,
       request_rov_config,
       set_rov_config,
@@ -292,6 +295,23 @@ pub fn run() -> tauri::Result<()> {
       #[cfg(target_os = "linux")]
       fix_gtk_dpi();
       setup_handlers(app);
+      let app_handle = app.handle().clone();
+      tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_secs(SPLASHSCREEN_FALLBACK_SECONDS)).await;
+        if app_handle.get_webview_window("splashscreen").is_some() {
+          let message = format!(
+            "Splashscreen watchdog fired after {SPLASHSCREEN_FALLBACK_SECONDS}s on {}; revealing the main window",
+            std::env::consts::OS
+          );
+          log::log_startup_diagnostic(&message);
+          if let Err(error) = close_splashscreen(app_handle.clone()) {
+            let error_message = format!(
+              "Splashscreen watchdog failed to reveal the main window: {error}"
+            );
+            log::log_startup_diagnostic(&error_message);
+          }
+        }
+      });
       Ok(())
     });
 

--- a/src-tauri/src/log.rs
+++ b/src-tauri/src/log.rs
@@ -1,30 +1,34 @@
-use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, OnceLock};
 use tauri::{AppHandle, Emitter};
 
 use crate::models::log::{LogEntry, LogLevel, LogOrigin};
 
 static APP_HANDLE: OnceLock<AppHandle> = OnceLock::new();
+static LOG_LISTENER_READY: AtomicBool = AtomicBool::new(false);
+static PENDING_STARTUP_LOGS: OnceLock<Mutex<Vec<LogEntry>>> = OnceLock::new();
 
-fn emit_log(level: LogLevel, message: &str) {
+fn emit_log_entry(entry: &LogEntry) {
   if let Some(handle) = APP_HANDLE.get() {
-    if let Err(error) = handle.emit(
-      "log_message",
-      LogEntry {
-        origin: LogOrigin::Backend,
-        level,
-        message: message.to_string(),
-      },
-    ) {
+    if let Err(error) = handle.emit("log_message", entry) {
       eprintln!("Failed to emit backend log message: {error}");
-      eprintln!("{message}");
+      eprintln!("{}", entry.message);
     }
   } else {
-    match level {
-      LogLevel::Info => println!("INFO: {message}"),
-      LogLevel::Warn => println!("WARN: {message}"),
-      LogLevel::Error => eprintln!("ERROR: {message}"),
+    match entry.level {
+      LogLevel::Info => println!("INFO: {}", entry.message),
+      LogLevel::Warn => println!("WARN: {}", entry.message),
+      LogLevel::Error => eprintln!("ERROR: {}", entry.message),
     }
   }
+}
+
+fn emit_log(level: LogLevel, message: &str) {
+  emit_log_entry(&LogEntry {
+    origin: LogOrigin::Backend,
+    level,
+    message: message.to_string(),
+  });
 }
 
 pub fn log_init(app_handle: AppHandle) {
@@ -48,6 +52,41 @@ pub fn log_error(message: &str) {
   emit_log(LogLevel::Error, message);
 }
 
+pub fn log_startup_diagnostic(message: &str) {
+  let entry = LogEntry {
+    origin: LogOrigin::Backend,
+    level: LogLevel::Warn,
+    message: message.to_string(),
+  };
+  if LOG_LISTENER_READY.load(Ordering::Acquire) {
+    emit_log_entry(&entry);
+    return;
+  }
+
+  let pending = PENDING_STARTUP_LOGS.get_or_init(|| Mutex::new(Vec::new()));
+  if let Ok(mut entries) = pending.lock() {
+    if LOG_LISTENER_READY.load(Ordering::Acquire) {
+      drop(entries);
+      emit_log_entry(&entry);
+    } else {
+      entries.push(entry);
+    }
+  } else {
+    eprintln!("Unable to buffer startup diagnostic: {message}");
+  }
+}
+
+pub fn initialize_log_listener() -> Vec<LogEntry> {
+  let pending = PENDING_STARTUP_LOGS.get_or_init(|| Mutex::new(Vec::new()));
+  if let Ok(mut entries) = pending.lock() {
+    LOG_LISTENER_READY.store(true, Ordering::Release);
+    std::mem::take(&mut *entries)
+  } else {
+    LOG_LISTENER_READY.store(true, Ordering::Release);
+    Vec::new()
+  }
+}
+
 #[macro_export]
 macro_rules! log_info {
   ($($arg:tt)*) => ($crate::log::log_info(&format!($($arg)*)));
@@ -61,4 +100,22 @@ macro_rules! log_warn {
 #[macro_export]
 macro_rules! log_error {
   ($($arg:tt)*) => ($crate::log::log_error(&format!($($arg)*)));
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn startup_diagnostics_are_buffered_until_the_main_log_listener_is_ready() {
+    log_startup_diagnostic("buffered startup diagnostic");
+
+    let entries = initialize_log_listener();
+
+    assert!(entries.iter().any(|entry| {
+      matches!(entry.level, LogLevel::Warn)
+        && matches!(entry.origin, LogOrigin::Backend)
+        && entry.message == "buffered startup diagnostic"
+    }));
+  }
 }

--- a/src-tauri/src/log.rs
+++ b/src-tauri/src/log.rs
@@ -106,6 +106,9 @@ macro_rules! log_error {
 mod tests {
   use super::*;
 
+  /// # Panics
+  /// Panics if a startup diagnostic is not returned when the main listener is
+  /// initialized.
   #[test]
   fn startup_diagnostics_are_buffered_until_the_main_log_listener_is_ready() {
     log_startup_diagnostic("buffered startup diagnostic");

--- a/src-tauri/src/models/rov_config.rs
+++ b/src-tauri/src/models/rov_config.rs
@@ -168,6 +168,8 @@ impl Default for Camera {
 #[serde(rename_all = "camelCase")]
 pub struct RovConfig {
   pub firmware_version: String,
+  #[serde(default)]
+  pub config_schema_version: u32,
   pub mcu_firmware_version: String,
   pub rov_name: String,
   pub mcu_board: McuBoard,
@@ -317,6 +319,7 @@ mod tests {
   fn sample_rov_config() -> RovConfig {
     RovConfig {
       firmware_version: "1.2.3".to_string(),
+      config_schema_version: 1,
       mcu_firmware_version: "4.5.6".to_string(),
       rov_name: "Manafish".to_string(),
       mcu_board: McuBoard::Pico2,

--- a/src-tauri/src/models/rov_config.rs
+++ b/src-tauri/src/models/rov_config.rs
@@ -74,7 +74,6 @@ pub struct Power {
   pub regulator_limit: f32,
   pub min_battery_voltage: f32,
   pub max_battery_voltage: f32,
-  pub internal_resistance: f32,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
@@ -350,7 +349,6 @@ mod tests {
         regulator_limit: 0.8,
         min_battery_voltage: 14.0,
         max_battery_voltage: 16.8,
-        internal_resistance: 0.02,
       },
       camera: sample_camera(),
       ip_address: "10.10.10.10".to_string(),

--- a/src-tauri/src/models/rov_config.rs
+++ b/src-tauri/src/models/rov_config.rs
@@ -168,8 +168,6 @@ impl Default for Camera {
 #[serde(rename_all = "camelCase")]
 pub struct RovConfig {
   pub firmware_version: String,
-  #[serde(default)]
-  pub config_schema_version: u32,
   pub mcu_firmware_version: String,
   pub rov_name: String,
   pub mcu_board: McuBoard,
@@ -319,7 +317,6 @@ mod tests {
   fn sample_rov_config() -> RovConfig {
     RovConfig {
       firmware_version: "1.2.3".to_string(),
-      config_schema_version: 1,
       mcu_firmware_version: "4.5.6".to_string(),
       rov_name: "Manafish".to_string(),
       mcu_board: McuBoard::Pico2,

--- a/src-tauri/src/websocket/send.rs
+++ b/src-tauri/src/websocket/send.rs
@@ -127,7 +127,7 @@ pub async fn handle_import_rov_config(
   state: &State<'_, MessageSendChannelState>,
   payload: serde_json::Value,
 ) -> Result<(), String> {
-  send_message(&state.tx, WebsocketMessage::ImportConfig(payload), "ImportConfig").await
+  send_message_and_wait(&state.tx, WebsocketMessage::ImportConfig(payload), "ImportConfig").await
 }
 
 /// # Errors

--- a/src/features/settings/forms/Mcu.tsx
+++ b/src/features/settings/forms/Mcu.tsx
@@ -1,10 +1,8 @@
-import type { Component, JSXElement } from 'solid-js';
-
 import { createListCollection } from '@ark-ui/solid/collection';
 import { Button } from '@manafishrov/ui/button';
 import { type SelectFieldProps, useAppForm } from '@manafishrov/ui/form';
 import { SelectItem } from '@manafishrov/ui/select';
-import { z } from 'zod';
+import { createMemo, type Component, type JSXElement } from 'solid-js';
 
 import { logError } from '@/lib/log';
 import * as m from '@/paraglide/messages';
@@ -14,9 +12,17 @@ import {
   McuBoard,
   ThrusterProtocol,
   rovConfigStore,
-  type RovConfig,
 } from '@/stores/rovConfig';
 import { flashMcuFirmware, setRovConfig } from '@/tauri';
+
+import {
+  formSchema,
+  getCompatibleDshotSpeed,
+  getDshotSpeedFormValue,
+  parseDshotSpeed,
+  type McuFormValues,
+} from './mcu/schema';
+import { updateMcuConfig, type ResolvedMcuConfig } from './mcu/update';
 
 type SelectOption = { value: string; label: string; disabled?: boolean };
 type SelectCollection = ReturnType<typeof createListCollection<SelectOption>>;
@@ -67,67 +73,6 @@ const createCurrentSensingModes = (): SelectCollection =>
     ],
   });
 
-const formSchema = z.object({
-  mcuBoard: z.array(z.enum([McuBoard.pico, McuBoard.pico2])).length(1),
-  thrusterProtocol: z.array(z.enum([ThrusterProtocol.pwm, ThrusterProtocol.dshot])).length(1),
-  dshotSpeed: z.array(z.enum(['150', '300', '600', '1200'])).length(1),
-  currentSensingMode: z
-    .array(z.enum([CurrentSensingMode.perMotor, CurrentSensingMode.sharedBus]))
-    .length(1),
-});
-
-type McuFormValues = z.infer<typeof formSchema>;
-
-const parseDshotSpeed = (
-  value: string | undefined,
-  fallback: (typeof DshotSpeed)[keyof typeof DshotSpeed],
-): (typeof DshotSpeed)[keyof typeof DshotSpeed] => {
-  switch (value ?? '') {
-    case '150': {
-      return DshotSpeed.dshot150;
-    }
-    case '300': {
-      return DshotSpeed.dshot300;
-    }
-    case '600': {
-      return DshotSpeed.dshot600;
-    }
-    case '1200': {
-      return DshotSpeed.dshot1200;
-    }
-    default: {
-      return fallback;
-    }
-  }
-};
-
-const getDshotSpeedFormValue = (
-  value: (typeof DshotSpeed)[keyof typeof DshotSpeed],
-): McuFormValues['dshotSpeed'][number] => {
-  switch (value) {
-    case DshotSpeed.dshot150: {
-      return '150';
-    }
-    case DshotSpeed.dshot300: {
-      return '300';
-    }
-    case DshotSpeed.dshot600: {
-      return '600';
-    }
-    case DshotSpeed.dshot1200: {
-      return '1200';
-    }
-    default: {
-      return '300';
-    }
-  }
-};
-
-type ResolvedMcuConfig = Pick<
-  RovConfig,
-  'mcuBoard' | 'thrusterProtocol' | 'dshotSpeed' | 'currentSensingMode'
->;
-
 const resolveFormValues = (value: McuFormValues): ResolvedMcuConfig => ({
   mcuBoard: value.mcuBoard[0] ?? rovConfigStore.mcuBoard,
   thrusterProtocol: value.thrusterProtocol[0] ?? rovConfigStore.thrusterProtocol,
@@ -135,18 +80,20 @@ const resolveFormValues = (value: McuFormValues): ResolvedMcuConfig => ({
   currentSensingMode: value.currentSensingMode[0] ?? rovConfigStore.currentSensingMode,
 });
 
+const flashMcuFirmwareWithLogging = (board: ResolvedMcuConfig['mcuBoard']): Promise<void> =>
+  flashMcuFirmware(board).catch((error: unknown): never => {
+    logError('Failed to flash MCU firmware:', error);
+    throw error;
+  });
+
 const submitMcuConfig = (value: McuFormValues): Promise<void> => {
   const resolved = resolveFormValues(value);
-  const boardChanged = resolved.mcuBoard !== rovConfigStore.mcuBoard;
-  const result = setRovConfig(resolved);
+  const previousBoard = rovConfigStore.mcuBoard;
 
-  if (boardChanged) {
-    flashMcuFirmware(resolved.mcuBoard).catch((error: unknown): void => {
-      logError('Failed to flash MCU firmware:', error);
-    });
-  }
-
-  return result;
+  return updateMcuConfig(
+    { config: resolved, previousBoard },
+    { setConfig: setRovConfig, flashFirmware: flashMcuFirmwareWithLogging },
+  );
 };
 
 type AppFieldContext = {
@@ -161,6 +108,7 @@ type AppFieldComponent = Component<{
 const McuBoardSelectField: Component<{
   AppField: AppFieldComponent;
   boards: SelectCollection;
+  onBoardChange: (board: McuFormValues['mcuBoard'][number]) => void;
   onFlashFirmware: () => void;
 }> = (props) => (
   <props.AppField name='mcuBoard'>
@@ -170,6 +118,12 @@ const McuBoardSelectField: Component<{
         description={m.general_rov_settings_mcu_board_description()}
         collection={props.boards}
         placeholder={m.general_rov_settings_mcu_board_select_placeholder()}
+        onValueChange={(details): void => {
+          const [board] = details.value;
+          if (board === McuBoard.pico || board === McuBoard.pico2) {
+            props.onBoardChange(board);
+          }
+        }}
         trailingAddon={
           <Button
             class='w-20'
@@ -268,13 +222,24 @@ const handleFlashFirmware = (): void => {
 export const Mcu: Component = () => {
   const boards = createMcuBoards();
   const protocols = createThrusterProtocols();
-  const dshotSpeeds = createDshotSpeeds(rovConfigStore.mcuBoard);
   const currentSensingModes = createCurrentSensingModes();
   const form = useAppForm(() => ({
     validators: { onChange: formSchema, onSubmit: formSchema },
     defaultValues: getDefaultFormValues(),
     onSubmit: ({ value }: { value: McuFormValues }): Promise<void> => submitMcuConfig(value),
   }));
+  const selectedMcuBoard = form.useSelector(
+    (state) => state.values.mcuBoard[0] ?? rovConfigStore.mcuBoard,
+  );
+  const dshotSpeeds = createMemo(() => createDshotSpeeds(selectedMcuBoard()));
+  const handleMcuBoardChange = (board: McuFormValues['mcuBoard'][number]): void => {
+    const currentSpeed = form.getFieldValue('dshotSpeed')[0] ?? '300';
+    const compatibleSpeed = getCompatibleDshotSpeed(board, currentSpeed);
+    if (compatibleSpeed !== currentSpeed) {
+      form.setFieldValue('dshotSpeed', [compatibleSpeed]);
+    }
+    form.setFieldValue('mcuBoard', [board]);
+  };
 
   return (
     <form.AppForm>
@@ -282,12 +247,13 @@ export const Mcu: Component = () => {
         <McuBoardSelectField
           AppField={form.AppField}
           boards={boards}
+          onBoardChange={handleMcuBoardChange}
           onFlashFirmware={handleFlashFirmware}
         />
         <ThrusterProtocolSelectField AppField={form.AppField} protocols={protocols} />
         <DshotSpeedSelectField
           AppField={form.AppField}
-          speeds={dshotSpeeds}
+          speeds={dshotSpeeds()}
           disabled={rovConfigStore.thrusterProtocol !== ThrusterProtocol.dshot}
         />
         <CurrentSensingModeSelectField AppField={form.AppField} modes={currentSensingModes} />

--- a/src/features/settings/forms/Power.tsx
+++ b/src/features/settings/forms/Power.tsx
@@ -34,7 +34,6 @@ const formSchema = z
     regulatorLimit: z.array(z.number().min(0).max(MAX_POWER)),
     minBatteryVoltage: z.number().positive(m.validation_must_be_positive_voltage()),
     maxBatteryVoltage: z.number().positive(m.validation_must_be_positive_voltage()),
-    internalResistance: z.number().min(0),
   })
   .refine((data) => data.minBatteryVoltage < data.maxBatteryVoltage, {
     message: m.validation_min_voltage_less_than_max(),
@@ -62,11 +61,7 @@ type PowerFieldApi = {
   }) => JSXElement;
 };
 
-type PowerFieldName =
-  | PowerSliderName
-  | 'minBatteryVoltage'
-  | 'maxBatteryVoltage'
-  | 'internalResistance';
+type PowerFieldName = PowerSliderName | 'minBatteryVoltage' | 'maxBatteryVoltage';
 
 type PowerFieldRenderer = (props: {
   name: PowerFieldName;
@@ -147,16 +142,6 @@ const PowerVoltageFields: Component<{ AppField: PowerFieldRenderer }> = (props) 
         />
       )}
     </props.AppField>
-    <props.AppField name='internalResistance'>
-      {(field) => (
-        <field.NumberInputField
-          label={m.power_internal_resistance_label()}
-          description={m.power_internal_resistance_description()}
-          min={0}
-          step={0.001}
-        />
-      )}
-    </props.AppField>
   </>
 );
 
@@ -215,7 +200,6 @@ const submitPowerSettings = (value: z.infer<typeof formSchema>): Promise<void> =
       regulatorLimit,
       minBatteryVoltage: value.minBatteryVoltage,
       maxBatteryVoltage: value.maxBatteryVoltage,
-      internalResistance: value.internalResistance,
     },
   });
 };
@@ -276,7 +260,6 @@ export const Power: Component = () => {
       regulatorLimit: [rovConfigStore.power.regulatorLimit],
       minBatteryVoltage: rovConfigStore.power.minBatteryVoltage,
       maxBatteryVoltage: rovConfigStore.power.maxBatteryVoltage,
-      internalResistance: rovConfigStore.power.internalResistance,
     },
     onSubmit: ({ value }): Promise<void> => submitPowerSettings(value),
   }));

--- a/src/features/settings/forms/mcu/schema.test.ts
+++ b/src/features/settings/forms/mcu/schema.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
-import { CurrentSensingMode, McuBoard, ThrusterProtocol } from '@/stores/rovConfig';
+import { CurrentSensingMode, DshotSpeed, McuBoard, ThrusterProtocol } from '@/stores/rovConfig';
 
-import { formSchema, getCompatibleDshotSpeed } from './schema';
+import {
+  formSchema,
+  getCompatibleDshotSpeed,
+  getDshotSpeedFormValue,
+  parseDshotSpeed,
+} from './schema';
 
 const values = {
   mcuBoard: [McuBoard.pico],
@@ -32,5 +37,26 @@ describe('MCU settings schema', () => {
   it('preserves supported speeds and Pico 2 DShot1200', () => {
     expect(getCompatibleDshotSpeed(McuBoard.pico, '300')).toBe('300');
     expect(getCompatibleDshotSpeed(McuBoard.pico2, '1200')).toBe('1200');
+  });
+
+  it('round trips every supported DShot speed', () => {
+    const speeds = [
+      ['150', DshotSpeed.dshot150],
+      ['300', DshotSpeed.dshot300],
+      ['600', DshotSpeed.dshot600],
+      ['1200', DshotSpeed.dshot1200],
+    ] as const;
+
+    for (const [formValue, configValue] of speeds) {
+      expect(parseDshotSpeed(formValue, DshotSpeed.dshot300)).toBe(configValue);
+      expect(getDshotSpeedFormValue(configValue)).toBe(formValue);
+    }
+  });
+
+  it('uses the provided fallback for unknown and missing DShot speeds', () => {
+    const missingValue = new Map<string, string>().get('missing');
+
+    expect(parseDshotSpeed('invalid', DshotSpeed.dshot600)).toBe(DshotSpeed.dshot600);
+    expect(parseDshotSpeed(missingValue, DshotSpeed.dshot150)).toBe(DshotSpeed.dshot150);
   });
 });

--- a/src/features/settings/forms/mcu/schema.test.ts
+++ b/src/features/settings/forms/mcu/schema.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { CurrentSensingMode, McuBoard, ThrusterProtocol } from '@/stores/rovConfig';
+
+import { formSchema, getCompatibleDshotSpeed } from './schema';
+
+const values = {
+  mcuBoard: [McuBoard.pico],
+  thrusterProtocol: [ThrusterProtocol.dshot],
+  dshotSpeed: ['1200'],
+  currentSensingMode: [CurrentSensingMode.perMotor],
+} as const;
+
+describe('MCU settings schema', () => {
+  it('rejects DShot1200 for a regular Pico', () => {
+    expect(formSchema.safeParse(values).success).toBe(false);
+  });
+
+  it('accepts DShot1200 for Pico 2', () => {
+    expect(
+      formSchema.safeParse({
+        ...values,
+        mcuBoard: [McuBoard.pico2],
+      }).success,
+    ).toBe(true);
+  });
+
+  it('downgrades DShot1200 to DShot600 when switching to a regular Pico', () => {
+    expect(getCompatibleDshotSpeed(McuBoard.pico, '1200')).toBe('600');
+  });
+
+  it('preserves supported speeds and Pico 2 DShot1200', () => {
+    expect(getCompatibleDshotSpeed(McuBoard.pico, '300')).toBe('300');
+    expect(getCompatibleDshotSpeed(McuBoard.pico2, '1200')).toBe('1200');
+  });
+});

--- a/src/features/settings/forms/mcu/schema.ts
+++ b/src/features/settings/forms/mcu/schema.ts
@@ -1,0 +1,75 @@
+import zod from 'zod';
+
+import { CurrentSensingMode, DshotSpeed, McuBoard, ThrusterProtocol } from '@/stores/rovConfig';
+
+export const formSchema = zod
+  .object({
+    mcuBoard: zod.array(zod.enum([McuBoard.pico, McuBoard.pico2])).length(1),
+    thrusterProtocol: zod.array(zod.enum([ThrusterProtocol.pwm, ThrusterProtocol.dshot])).length(1),
+    dshotSpeed: zod.array(zod.enum(['150', '300', '600', '1200'])).length(1),
+    currentSensingMode: zod
+      .array(zod.enum([CurrentSensingMode.perMotor, CurrentSensingMode.sharedBus]))
+      .length(1),
+  })
+  .superRefine((value, context): void => {
+    if (value.mcuBoard[0] === McuBoard.pico && value.dshotSpeed[0] === '1200') {
+      context.addIssue({
+        code: 'custom',
+        path: ['dshotSpeed'],
+        message: 'DShot1200 requires Pico 2',
+      });
+    }
+  });
+
+export type McuFormValues = zod.infer<typeof formSchema>;
+
+export const getCompatibleDshotSpeed = (
+  board: McuFormValues['mcuBoard'][number],
+  speed: McuFormValues['dshotSpeed'][number],
+): McuFormValues['dshotSpeed'][number] =>
+  board === McuBoard.pico && speed === '1200' ? '600' : speed;
+
+export const parseDshotSpeed = (
+  value: string | undefined,
+  fallback: (typeof DshotSpeed)[keyof typeof DshotSpeed],
+): (typeof DshotSpeed)[keyof typeof DshotSpeed] => {
+  switch (value ?? '') {
+    case '150': {
+      return DshotSpeed.dshot150;
+    }
+    case '300': {
+      return DshotSpeed.dshot300;
+    }
+    case '600': {
+      return DshotSpeed.dshot600;
+    }
+    case '1200': {
+      return DshotSpeed.dshot1200;
+    }
+    default: {
+      return fallback;
+    }
+  }
+};
+
+export const getDshotSpeedFormValue = (
+  value: (typeof DshotSpeed)[keyof typeof DshotSpeed],
+): McuFormValues['dshotSpeed'][number] => {
+  switch (value) {
+    case DshotSpeed.dshot150: {
+      return '150';
+    }
+    case DshotSpeed.dshot300: {
+      return '300';
+    }
+    case DshotSpeed.dshot600: {
+      return '600';
+    }
+    case DshotSpeed.dshot1200: {
+      return '1200';
+    }
+    default: {
+      return '300';
+    }
+  }
+};

--- a/src/features/settings/forms/mcu/schema.ts
+++ b/src/features/settings/forms/mcu/schema.ts
@@ -2,6 +2,14 @@ import zod from 'zod';
 
 import { CurrentSensingMode, DshotSpeed, McuBoard, ThrusterProtocol } from '@/stores/rovConfig';
 
+type McuBoardValue = (typeof McuBoard)[keyof typeof McuBoard];
+type DshotSpeedFormValue = '150' | '300' | '600' | '1200';
+
+export const getCompatibleDshotSpeed = (
+  board: McuBoardValue,
+  speed: DshotSpeedFormValue,
+): DshotSpeedFormValue => (board === McuBoard.pico && speed === '1200' ? '600' : speed);
+
 export const formSchema = zod
   .object({
     mcuBoard: zod.array(zod.enum([McuBoard.pico, McuBoard.pico2])).length(1),
@@ -12,7 +20,9 @@ export const formSchema = zod
       .length(1),
   })
   .superRefine((value, context): void => {
-    if (value.mcuBoard[0] === McuBoard.pico && value.dshotSpeed[0] === '1200') {
+    const [board] = value.mcuBoard;
+    const [speed] = value.dshotSpeed;
+    if (board && speed && getCompatibleDshotSpeed(board, speed) !== speed) {
       context.addIssue({
         code: 'custom',
         path: ['dshotSpeed'],
@@ -22,12 +32,6 @@ export const formSchema = zod
   });
 
 export type McuFormValues = zod.infer<typeof formSchema>;
-
-export const getCompatibleDshotSpeed = (
-  board: McuFormValues['mcuBoard'][number],
-  speed: McuFormValues['dshotSpeed'][number],
-): McuFormValues['dshotSpeed'][number] =>
-  board === McuBoard.pico && speed === '1200' ? '600' : speed;
 
 export const parseDshotSpeed = (
   value: string | undefined,

--- a/src/features/settings/forms/mcu/update.test.ts
+++ b/src/features/settings/forms/mcu/update.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import { CurrentSensingMode, DshotSpeed, McuBoard, ThrusterProtocol } from '@/stores/rovConfig';
+
+import { updateMcuConfig, type ResolvedMcuConfig } from './update';
+
+const config: ResolvedMcuConfig = {
+  mcuBoard: McuBoard.pico2,
+  thrusterProtocol: ThrusterProtocol.dshot,
+  dshotSpeed: DshotSpeed.dshot1200,
+  currentSensingMode: CurrentSensingMode.perMotor,
+};
+
+describe('changed MCU board', () => {
+  it('waits for the config update before flashing', () => {
+    const calls: string[] = [];
+    const update = updateMcuConfig(
+      { config, previousBoard: McuBoard.pico },
+      {
+        setConfig: () => {
+          calls.push('config');
+          return Promise.resolve();
+        },
+        flashFirmware: () => {
+          calls.push('flash');
+          return Promise.resolve();
+        },
+      },
+    );
+
+    expect(calls).toEqual(['config']);
+    return update.then(() => {
+      expect(calls).toEqual(['config', 'flash']);
+    });
+  });
+
+  it('does not flash when the config update fails', () => {
+    let flashCalled = false;
+
+    return expect(
+      updateMcuConfig(
+        { config, previousBoard: McuBoard.pico },
+        {
+          setConfig: () => Promise.reject(new Error('config failed')),
+          flashFirmware: () => {
+            flashCalled = true;
+            return Promise.resolve();
+          },
+        },
+      ),
+    )
+      .rejects.toThrow('config failed')
+      .then(() => {
+        expect(flashCalled).toBe(false);
+      });
+  });
+});
+
+describe('unchanged MCU board and failures', () => {
+  it('does not flash when the board is unchanged', () => {
+    let flashCalled = false;
+
+    return updateMcuConfig(
+      { config, previousBoard: McuBoard.pico2 },
+      {
+        setConfig: () => Promise.resolve(),
+        flashFirmware: () => {
+          flashCalled = true;
+          return Promise.resolve();
+        },
+      },
+    ).then(() => {
+      expect(flashCalled).toBe(false);
+    });
+  });
+
+  it('propagates flash failures', () =>
+    expect(
+      updateMcuConfig(
+        { config, previousBoard: McuBoard.pico },
+        {
+          setConfig: () => Promise.resolve(),
+          flashFirmware: () => Promise.reject(new Error('flash failed')),
+        },
+      ),
+    ).rejects.toThrow('flash failed'));
+});

--- a/src/features/settings/forms/mcu/update.ts
+++ b/src/features/settings/forms/mcu/update.ts
@@ -1,0 +1,24 @@
+import type { RovConfig } from '@/stores/rovConfig';
+
+export type ResolvedMcuConfig = Pick<
+  RovConfig,
+  'mcuBoard' | 'thrusterProtocol' | 'dshotSpeed' | 'currentSensingMode'
+>;
+
+type McuConfigUpdate = {
+  config: ResolvedMcuConfig;
+  previousBoard: RovConfig['mcuBoard'];
+};
+
+type McuConfigDependencies = {
+  setConfig: (config: ResolvedMcuConfig) => Promise<void>;
+  flashFirmware: (board: RovConfig['mcuBoard']) => Promise<void>;
+};
+
+export const updateMcuConfig = (
+  { config, previousBoard }: McuConfigUpdate,
+  { setConfig, flashFirmware }: McuConfigDependencies,
+): Promise<void> =>
+  setConfig(config).then(() =>
+    config.mcuBoard === previousBoard ? Promise.resolve() : flashFirmware(config.mcuBoard),
+  );

--- a/src/routes/settings/route.tsx
+++ b/src/routes/settings/route.tsx
@@ -10,11 +10,11 @@ import {
 import { SidebarInset, SidebarLayout, SidebarProvider } from '@manafishrov/ui/sidebar';
 import { Outlet, createFileRoute, useLocation, useNavigate } from '@tanstack/solid-router';
 import { getCurrentWindow } from '@tauri-apps/api/window';
-import { createEffect, createSignal, onCleanup, onMount, type Component } from 'solid-js';
+import { createEffect, createSignal, onCleanup, onMount, Show, type Component } from 'solid-js';
 
 import { SettingsSidebar } from '@/features/settings/SettingsSidebar';
 import { connectionStatusStore } from '@/stores/connectionStatus';
-import { requestRovConfig } from '@/tauri';
+import { requestRovConfig, rovConfigRevision } from '@/tauri';
 
 const noop = function noop(): void {
   // Noop
@@ -72,7 +72,13 @@ const SettingsLayout: Component = () => {
             >
               <ScrollAreaContent class='@container'>
                 <div class='relative mx-auto w-full max-w-3xl p-4 md:p-8'>
-                  <Outlet />
+                  <Show when={rovConfigRevision()} keyed fallback={<Outlet />}>
+                    {(revision) => (
+                      <div class='contents' data-rov-config-revision={revision}>
+                        <Outlet />
+                      </div>
+                    )}
+                  </Show>
                 </div>
               </ScrollAreaContent>
             </ScrollAreaViewport>

--- a/src/stores/rovConfig.ts
+++ b/src/stores/rovConfig.ts
@@ -151,6 +151,7 @@ type Camera = {
 
 type RovConfig = {
   firmwareVersion: string;
+  configSchemaVersion: number;
   mcuFirmwareVersion: string;
   rovName: string;
   mcuBoard: McuBoard;
@@ -199,6 +200,7 @@ const defaultThrusterAllocation: ThrusterAllocation = [
 
 const defaultRovConfig: RovConfig = {
   firmwareVersion: m.common_not_available(),
+  configSchemaVersion: 0,
   mcuFirmwareVersion: m.common_not_available(),
   rovName: 'Manafish Nomad',
   mcuBoard: McuBoard.pico,

--- a/src/stores/rovConfig.ts
+++ b/src/stores/rovConfig.ts
@@ -126,7 +126,6 @@ type Power = {
   regulatorLimit: number;
   minBatteryVoltage: number;
   maxBatteryVoltage: number;
-  internalResistance: number;
 };
 
 type Camera = {
@@ -185,7 +184,7 @@ const createDefaultPitchRollYawAxisConfig = (): AxisConfig => ({
   kd: 0.6,
   rate: 120,
 });
-const createDefaultDepthAxisConfig = (): AxisConfig => ({ kp: 6, ki: 2, kd: 0.6, rate: 0.5 });
+const createDefaultDepthAxisConfig = (): AxisConfig => ({ kp: 2, ki: 0, kd: 0.5, rate: 0.5 });
 
 const defaultThrusterAllocation: ThrusterAllocation = [
   [1, 1, 0, 0, -1, 0, 0, 0],
@@ -228,7 +227,6 @@ const defaultRovConfig: RovConfig = {
     regulatorLimit: 30,
     minBatteryVoltage: 16,
     maxBatteryVoltage: 20.5,
-    internalResistance: 0.1,
   },
   camera: {
     // Highest supported preset (see camera/constants.ts RESOLUTION_OPTIONS) at the full-FOV framerate ceiling for that resolution.

--- a/src/stores/rovConfig.ts
+++ b/src/stores/rovConfig.ts
@@ -151,7 +151,6 @@ type Camera = {
 
 type RovConfig = {
   firmwareVersion: string;
-  configSchemaVersion: number;
   mcuFirmwareVersion: string;
   rovName: string;
   mcuBoard: McuBoard;
@@ -200,7 +199,6 @@ const defaultThrusterAllocation: ThrusterAllocation = [
 
 const defaultRovConfig: RovConfig = {
   firmwareVersion: m.common_not_available(),
-  configSchemaVersion: 0,
   mcuFirmwareVersion: m.common_not_available(),
   rovName: 'Manafish Nomad',
   mcuBoard: McuBoard.pico,

--- a/src/tauri/core.ts
+++ b/src/tauri/core.ts
@@ -27,6 +27,7 @@ export class DisposableStack {
 
 export type ListenerOptions = {
   warnOnly?: boolean;
+  rejectOnSetupFailure?: boolean;
 };
 
 export const createListener = <Payload>(
@@ -53,6 +54,9 @@ export const createListener = <Payload>(
     } else {
       logError(errorMsg, error);
       toast.create({ title: m.toasts_listener_setup_failed({ event: eventName }), type: 'error' });
+    }
+    if (options && options.rejectOnSetupFailure === true) {
+      throw error;
     }
     return noop;
   });

--- a/src/tauri/index.ts
+++ b/src/tauri/index.ts
@@ -15,7 +15,12 @@ export { sendCustomAction } from '@/tauri/customAction';
 export { setDesiredDepth } from '@/tauri/desiredDepth';
 export { initializeVideoDirectory, recoverTempRecordings, saveRecording } from '@/tauri/recording';
 export { regulatorSuggestions, startRegulatorAutoTuning } from '@/tauri/regulator';
-export { importRovConfig, requestRovConfig, setRovConfig } from '@/tauri/rovConfig';
+export {
+  importRovConfig,
+  requestRovConfig,
+  rovConfigRevision,
+  setRovConfig,
+} from '@/tauri/rovConfig';
 export { updateRovConnection } from '@/tauri/rovConnection';
 export {
   cancelFirmwareFlash,

--- a/src/tauri/logs.test.ts
+++ b/src/tauri/logs.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  createListener: vi.fn(),
+  createLogRecord: vi.fn(),
+  invokeCommand: vi.fn(),
+}));
+
+vi.mock('@/lib/log', () => ({ createLogRecord: mocks.createLogRecord }));
+vi.mock('@/tauri/core', () => ({
+  createListener: mocks.createListener,
+  invokeCommand: mocks.invokeCommand,
+}));
+
+import { setupLogsListener } from '@/tauri/logs';
+
+describe('setupLogsListener', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not initialize backend logging when event registration fails', () => {
+    mocks.createListener.mockRejectedValue(new Error('registration failed'));
+
+    return expect(setupLogsListener())
+      .rejects.toThrow('registration failed')
+      .then(() => {
+        expect(mocks.invokeCommand).not.toHaveBeenCalled();
+        expect(mocks.createListener).toHaveBeenCalledWith('log_message', expect.any(Function), {
+          rejectOnSetupFailure: true,
+          warnOnly: true,
+        });
+      });
+  });
+});

--- a/src/tauri/logs.ts
+++ b/src/tauri/logs.ts
@@ -1,13 +1,21 @@
 import { createLogRecord, type LogEntry } from '@/lib/log';
-import { createListener } from '@/tauri/core';
+import { createListener, invokeCommand } from '@/tauri/core';
 
 const EVENT = 'log_message';
+const LISTENER_OPTIONS = { warnOnly: true } as const;
 
 const ignoreCreateLogRecordResult = (): void => {
   Number.isNaN(Number.NaN);
 };
 
+const persistLogEntry = (entry: LogEntry): Promise<void> => createLogRecord(entry);
+
 export const setupLogsListener = (): Promise<() => void> =>
   createListener<LogEntry>(EVENT, (entry): void => {
-    createLogRecord(entry).then(ignoreCreateLogRecordResult).catch(ignoreCreateLogRecordResult);
-  });
+    persistLogEntry(entry).then(ignoreCreateLogRecordResult).catch(ignoreCreateLogRecordResult);
+  }).then((unlisten) =>
+    invokeCommand<LogEntry[]>('initialize_log_listener', {}, LISTENER_OPTIONS)
+      .then((entries) => Promise.all(entries.map((entry) => persistLogEntry(entry))))
+      .then(() => unlisten)
+      .catch(() => unlisten),
+  );

--- a/src/tauri/logs.ts
+++ b/src/tauri/logs.ts
@@ -2,7 +2,8 @@ import { createLogRecord, type LogEntry } from '@/lib/log';
 import { createListener, invokeCommand } from '@/tauri/core';
 
 const EVENT = 'log_message';
-const LISTENER_OPTIONS = { warnOnly: true } as const;
+const LISTENER_OPTIONS = { warnOnly: true, rejectOnSetupFailure: true } as const;
+const INVOKE_OPTIONS = { warnOnly: true } as const;
 
 const ignoreCreateLogRecordResult = (): void => {
   Number.isNaN(Number.NaN);
@@ -11,10 +12,14 @@ const ignoreCreateLogRecordResult = (): void => {
 const persistLogEntry = (entry: LogEntry): Promise<void> => createLogRecord(entry);
 
 export const setupLogsListener = (): Promise<() => void> =>
-  createListener<LogEntry>(EVENT, (entry): void => {
-    persistLogEntry(entry).then(ignoreCreateLogRecordResult).catch(ignoreCreateLogRecordResult);
-  }).then((unlisten) =>
-    invokeCommand<LogEntry[]>('initialize_log_listener', {}, LISTENER_OPTIONS)
+  createListener<LogEntry>(
+    EVENT,
+    (entry): void => {
+      persistLogEntry(entry).then(ignoreCreateLogRecordResult).catch(ignoreCreateLogRecordResult);
+    },
+    LISTENER_OPTIONS,
+  ).then((unlisten) =>
+    invokeCommand<LogEntry[]>('initialize_log_listener', {}, INVOKE_OPTIONS)
       .then((entries) => Promise.all(entries.map((entry) => persistLogEntry(entry))))
       .then(() => unlisten)
       .catch(() => unlisten),

--- a/src/tauri/rovConfig.ts
+++ b/src/tauri/rovConfig.ts
@@ -1,3 +1,4 @@
+import { createSignal } from 'solid-js';
 import { unwrap } from 'solid-js/store';
 
 import { connectionStatusStore } from '@/stores/connectionStatus';
@@ -7,9 +8,15 @@ import { createListener, invokeCommand } from '@/tauri/core';
 const EVENT = 'rov_config_received';
 
 const resolveVoid: () => void = () => 0;
+const [rovConfigRevision, setRovConfigRevision] = createSignal(0);
+
+const applyRemoteRovConfig = (config: RovConfig): void => {
+  setRovConfigStore(config);
+  setRovConfigRevision((revision) => revision + 1);
+};
 
 export const setupRovConfigListener = (): Promise<() => void> =>
-  createListener<RovConfig>(EVENT, setRovConfigStore);
+  createListener<RovConfig>(EVENT, applyRemoteRovConfig);
 
 export const requestRovConfig = (): Promise<void> | undefined => {
   if (!connectionStatusStore.isConnected) {
@@ -35,3 +42,5 @@ export const setRovConfig = (newConfigOptions: Partial<RovConfig>): Promise<void
 
 export const importRovConfig = (payload: unknown): Promise<void> =>
   invokeCommand('import_rov_config', { payload }).then(resolveVoid);
+
+export { rovConfigRevision };


### PR DESCRIPTION
## Summary

- install the exact selected release-candidate manifest instead of falling back to stable
- remove the unused battery internal-resistance setting and use the new depth-hold defaults
- refresh settings immediately after importing configuration
- prevent regular Pico plus DShot1200, downgrade safely when changing boards, and wait for configuration delivery before flashing
- propagate WebSocket delivery failures and route delayed splash diagnostics into the normal app log system
- add regression coverage for MCU compatibility and config-before-flash ordering

## Validation

- bun run fmt:check
- bun run lint
- bun run test (51 tests)
- bun run build
- bun run fmt:rs:check
- bun run lint:rs

## Compatibility

This PR can be reviewed and merged independently. The complete thruster switching and telemetry fixes require the matching firmware and MCU releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - MCU settings now automatically adapt DShot speed options to the selected board.
  - Startup warnings are retained and displayed after log monitoring begins.
  - Settings refresh automatically when remote configuration changes.
- **Bug Fixes**
  - Improved splash screen recovery if startup takes too long.
  - Configuration imports now wait for delivery confirmation.
  - Updater matching is more reliable for stable and prerelease versions.
- **Changes**
  - Removed the battery internal resistance setting.
  - Updated default depth-control tuning values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->