### PR TITLE
refactor(status): require current firmware schema

### DIFF
--- a/messages/en-gb.json
+++ b/messages/en-gb.json
@@ -178,7 +178,6 @@
   "general_rov_settings_esc_firmware_flash_confirm_action": "Flash all ESCs",
   "general_rov_settings_esc_firmware_flash_pending": "The update continues on the ROV. Keep the main battery connected.",
   "general_rov_settings_esc_firmware_flash_progress": "ESC firmware update: {percent}%",
-  "general_rov_settings_esc_firmware_flash_unsupported": "Update the ROV system firmware to view and update electronic speed controller firmware.",
   "general_rov_settings_mcu_page_title": "ESC",
   "general_rov_settings_mcu_page_description": "Configure the thruster protocol, DShot speed, and ESC current sensing mode.",
   "general_rov_settings_firmware_page_title": "Firmware",

--- a/src-tauri/src/models/rov_status.rs
+++ b/src-tauri/src/models/rov_status.rs
@@ -11,47 +11,20 @@ pub struct SystemHealth {
 #[derive(Deserialize, Serialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct DeviceInfo {
-  #[serde(default)]
   pub mcu_firmware_version: String,
-  #[serde(default)]
   pub esc_firmware_versions: [Option<String>; 8],
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct EscFirmwareUpdate {
-  #[serde(default)]
   pub active: bool,
-  #[serde(default)]
   pub origin: Option<String>,
-  #[serde(default = "default_esc_update_stage")]
   pub stage: String,
-  #[serde(default)]
   pub progress: u8,
-  #[serde(default)]
   pub current_esc: Option<u8>,
-  #[serde(default)]
   pub target_version: Option<String>,
-  #[serde(default)]
   pub error: Option<String>,
-}
-
-fn default_esc_update_stage() -> String {
-  "idle".to_string()
-}
-
-impl Default for EscFirmwareUpdate {
-  fn default() -> Self {
-    Self {
-      active: false,
-      origin: None,
-      stage: default_esc_update_stage(),
-      progress: 0,
-      current_esc: None,
-      target_version: None,
-      error: None,
-    }
-  }
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
@@ -61,12 +34,9 @@ pub struct RovStatus {
   pub depth_hold: bool,
   pub battery_percentage: u8,
   pub current_draw: i32,
-  #[serde(default)]
   pub pi_undervoltage: bool,
   pub health: SystemHealth,
-  #[serde(default, skip_serializing_if = "Option::is_none")]
-  pub device_info: Option<DeviceInfo>,
-  #[serde(default)]
+  pub device_info: DeviceInfo,
   pub esc_firmware_update: EscFirmwareUpdate,
 }
 
@@ -74,15 +44,29 @@ pub struct RovStatus {
 mod tests {
   use super::RovStatus;
 
-  const BASE_STATUS: &str = r#"{
+  const CURRENT_STATUS: &str = r#"{
     "autoStabilization": false,
     "depthHold": false,
     "batteryPercentage": 75,
     "currentDraw": 12,
+    "piUndervoltage": false,
     "health": {
       "imuHealthy": true,
       "pressureSensorHealthy": true,
       "mcuHealthy": true
+    },
+    "deviceInfo": {
+      "mcuFirmwareVersion": "1.2.3-rc.1",
+      "escFirmwareVersions": ["2.20.0", null, null, null, null, null, null, null]
+    },
+    "escFirmwareUpdate": {
+      "active": false,
+      "origin": null,
+      "stage": "idle",
+      "progress": 0,
+      "currentEsc": null,
+      "targetVersion": null,
+      "error": null
     }
   }"#;
 
@@ -90,57 +74,45 @@ mod tests {
   /// Panics if a status with live device information cannot round-trip through JSON.
   #[test]
   fn preserves_live_device_info() {
-    let mut value: serde_json::Value = serde_json::from_str(BASE_STATUS).unwrap();
-    value["deviceInfo"] = serde_json::json!({
-      "mcuFirmwareVersion": "1.2.3",
-      "escFirmwareVersions": ["2.20.0", null, null, null, null, null, null, null]
-    });
-
-    let status: RovStatus = serde_json::from_value(value).unwrap();
+    let status: RovStatus = serde_json::from_str(CURRENT_STATUS).unwrap();
     let serialized = serde_json::to_value(&status).unwrap();
 
-    assert_eq!(serialized["deviceInfo"]["mcuFirmwareVersion"], "1.2.3");
+    assert_eq!(serialized["deviceInfo"]["mcuFirmwareVersion"], "1.2.3-rc.1");
     assert_eq!(serialized["deviceInfo"]["escFirmwareVersions"][0], "2.20.0");
   }
 
   /// # Panics
-  /// Panics if a legacy status no longer deserializes with safe defaults.
+  /// Panics if the current status fixture cannot be parsed as JSON.
   #[test]
-  fn accepts_legacy_status_without_device_info() {
-    let status: RovStatus = serde_json::from_str(BASE_STATUS).unwrap();
-    let serialized = serde_json::to_value(&status).unwrap();
+  fn rejects_status_without_current_required_fields() {
+    for field in ["piUndervoltage", "deviceInfo", "escFirmwareUpdate"] {
+      let mut value: serde_json::Value = serde_json::from_str(CURRENT_STATUS).unwrap();
+      value.as_object_mut().unwrap().remove(field);
 
-    assert!(serialized.get("deviceInfo").is_none());
-    assert!(!status.pi_undervoltage);
+      assert!(
+        serde_json::from_value::<RovStatus>(value).is_err(),
+        "status without {field} should be rejected"
+      );
+    }
   }
 
   /// # Panics
-  /// Panics if a partially populated device-info frame cannot be read safely.
+  /// Panics if the current status fixture cannot be parsed as JSON.
   #[test]
-  fn accepts_partial_device_info() {
-    let mut value: serde_json::Value = serde_json::from_str(BASE_STATUS).unwrap();
+  fn rejects_partial_device_info() {
+    let mut value: serde_json::Value = serde_json::from_str(CURRENT_STATUS).unwrap();
     value["deviceInfo"] = serde_json::json!({});
-    let status: RovStatus =
-      serde_json::from_value(value).expect("partial device info should use safe defaults");
 
-    let device_info = status.device_info.expect("device info should be present");
-    assert!(device_info.mcu_firmware_version.is_empty());
-    assert!(device_info.esc_firmware_versions.iter().all(Option::is_none));
+    assert!(serde_json::from_value::<RovStatus>(value).is_err());
   }
 
   /// # Panics
-  /// Panics if a partial ESC update object cannot use safe field defaults.
+  /// Panics if the current status fixture cannot be parsed as JSON.
   #[test]
-  fn accepts_partial_esc_firmware_update() {
-    let mut value: serde_json::Value = serde_json::from_str(BASE_STATUS).unwrap();
+  fn rejects_partial_esc_firmware_update() {
+    let mut value: serde_json::Value = serde_json::from_str(CURRENT_STATUS).unwrap();
     value["escFirmwareUpdate"] = serde_json::json!({"active": true, "progress": 40});
 
-    let status: RovStatus =
-      serde_json::from_value(value).expect("partial ESC update should use safe defaults");
-
-    assert!(status.esc_firmware_update.active);
-    assert_eq!(status.esc_firmware_update.progress, 40);
-    assert_eq!(status.esc_firmware_update.stage, "idle");
-    assert!(status.esc_firmware_update.origin.is_none());
+    assert!(serde_json::from_value::<RovStatus>(value).is_err());
   }
 }

--- a/src/features/settings/forms/EscFirmwareVersionCard.tsx
+++ b/src/features/settings/forms/EscFirmwareVersionCard.tsx
@@ -15,21 +15,8 @@ import * as m from '@/paraglide/messages';
 import { rovStatusStore, type EscFirmwareVersions } from '@/stores/rovStatus';
 import { flashEscFirmware } from '@/tauri';
 
-const unavailableVersions = (): EscFirmwareVersions => [
-  null,
-  null,
-  null,
-  null,
-  null,
-  null,
-  null,
-  null,
-];
-
 const getEscFirmwareVersions = (): EscFirmwareVersions =>
-  rovStatusStore.deviceInfoAvailable
-    ? rovStatusStore.deviceInfo.escFirmwareVersions
-    : unavailableVersions();
+  rovStatusStore.deviceInfo.escFirmwareVersions;
 
 const getCommonEscFirmwareVersion = (): string | null => {
   const versions = getEscFirmwareVersions();
@@ -56,20 +43,14 @@ const handleFlashEscFirmware = (): Promise<void> =>
   });
 
 const EscFirmwareFlashAction: Component = () => (
-  <span
-    title={
-      rovStatusStore.deviceInfoAvailable
-        ? ''
-        : m.general_rov_settings_esc_firmware_flash_unsupported()
-    }
-  >
+  <span>
     <ConfirmUpdateButton
       buttonLabel={m.general_rov_settings_esc_firmware_flash_button()}
       confirmLabel={m.general_rov_settings_esc_firmware_flash_confirm_action()}
       title={m.general_rov_settings_esc_firmware_flash_confirm_title()}
       description={<p>{m.general_rov_settings_esc_firmware_flash_confirm_description()}</p>}
       pendingDescription={m.general_rov_settings_esc_firmware_flash_pending()}
-      disabled={!rovStatusStore.deviceInfoAvailable || rovStatusStore.escFirmwareUpdate.active}
+      disabled={rovStatusStore.escFirmwareUpdate.active}
       onConfirm={handleFlashEscFirmware}
     />
   </span>

--- a/src/features/settings/forms/McuFirmwareVersionCard.tsx
+++ b/src/features/settings/forms/McuFirmwareVersionCard.tsx
@@ -15,8 +15,7 @@ import * as m from '@/paraglide/messages';
 import { rovStatusStore } from '@/stores/rovStatus';
 
 const getMcuFirmwareVersion = (): string => {
-  const { deviceInfo, deviceInfoAvailable } = rovStatusStore;
-  const version = deviceInfoAvailable ? deviceInfo.mcuFirmwareVersion : '';
+  const version = rovStatusStore.deviceInfo.mcuFirmwareVersion;
   if (version === '' || version === m.common_not_available()) {
     return m.common_not_available();
   }

--- a/src/stores/rovStatus.test.ts
+++ b/src/stores/rovStatus.test.ts
@@ -13,29 +13,42 @@ const status = {
     pressureSensorHealthy: true,
     mcuHealthy: true,
   },
+  deviceInfo: {
+    mcuFirmwareVersion: '1.2.3-rc.1',
+    escFirmwareVersions: [
+      '2.20.0',
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+    ] as EscFirmwareVersions,
+  },
+  escFirmwareUpdate: {
+    active: false,
+    origin: null,
+    stage: 'idle' as const,
+    progress: 0,
+    currentEsc: null,
+    targetVersion: null,
+    error: null,
+  },
 };
 
-describe('ROV status device information compatibility', () => {
-  test('tracks whether live device information is supported', () => {
+describe('ROV status device information', () => {
+  test('stores the required live device information', () => {
     setRovStatusStore(status);
-    expect(rovStatusStore.deviceInfoAvailable).toBe(false);
-    expect(rovStatusStore.deviceInfo.escFirmwareVersions).toEqual([
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-    ]);
+    expect(rovStatusStore.deviceInfo.mcuFirmwareVersion).toBe('1.2.3-rc.1');
+    expect(rovStatusStore.deviceInfo.escFirmwareVersions[0]).toBe('2.20.0');
 
     setRovStatusStore({
       ...status,
       deviceInfo: {
-        mcuFirmwareVersion: '1.2.3',
+        mcuFirmwareVersion: '1.2.4-rc.1',
         escFirmwareVersions: [
-          '2.20.0',
+          '2.21.0-rc.2',
           null,
           null,
           null,
@@ -46,7 +59,7 @@ describe('ROV status device information compatibility', () => {
         ] as EscFirmwareVersions,
       },
     });
-    expect(rovStatusStore.deviceInfoAvailable).toBe(true);
-    expect(rovStatusStore.deviceInfo.escFirmwareVersions[0]).toBe('2.20.0');
+    expect(rovStatusStore.deviceInfo.mcuFirmwareVersion).toBe('1.2.4-rc.1');
+    expect(rovStatusStore.deviceInfo.escFirmwareVersions[0]).toBe('2.21.0-rc.2');
   });
 });

--- a/src/stores/rovStatus.ts
+++ b/src/stores/rovStatus.ts
@@ -46,13 +46,7 @@ type RovStatus = {
   currentDraw: number;
   piUndervoltage: boolean;
   health: SystemHealth;
-  deviceInfo?: DeviceInfo;
-  escFirmwareUpdate?: EscFirmwareUpdate;
-};
-
-type RovStatusState = Omit<RovStatus, 'deviceInfo'> & {
   deviceInfo: DeviceInfo;
-  deviceInfoAvailable: boolean;
   escFirmwareUpdate: EscFirmwareUpdate;
 };
 
@@ -71,14 +65,13 @@ const defaultEscFirmwareUpdate: EscFirmwareUpdate = {
   error: null,
 };
 
-const [rovStatusStore, setRovStatusStoreInternal] = createStore<RovStatusState>({
+const [rovStatusStore, setRovStatusStoreInternal] = createStore<RovStatus>({
   autoStabilization: false,
   depthHold: false,
   batteryPercentage: 0,
   currentDraw: 0,
   piUndervoltage: false,
   deviceInfo: defaultDeviceInfo,
-  deviceInfoAvailable: false,
   escFirmwareUpdate: defaultEscFirmwareUpdate,
   health: {
     imuHealthy: false,
@@ -88,15 +81,7 @@ const [rovStatusStore, setRovStatusStoreInternal] = createStore<RovStatusState>(
 });
 
 const setRovStatusStore = (value: RovStatus): void => {
-  const deviceInfoAvailable = Boolean(value.deviceInfo);
-  setRovStatusStoreInternal(
-    reconcile({
-      ...value,
-      deviceInfo: value.deviceInfo ?? defaultDeviceInfo,
-      deviceInfoAvailable,
-      escFirmwareUpdate: value.escFirmwareUpdate ?? defaultEscFirmwareUpdate,
-    }),
-  );
+  setRovStatusStoreInternal(reconcile(value));
 };
 
 const setAutoStabilizationOptimistic = (value: boolean): void => {


### PR DESCRIPTION
The desktop app now requires the complete current ROV status schema instead of silently supplying defaults for older firmware messages.

- require Pi undervoltage, MCU and ESC device information, and ESC update state
- remove frontend availability flags and compatibility fallbacks
- consume live MCU and ESC versions directly
- reject missing or partial status objects in the Rust wire-model tests

This is an intentional compatibility break for the next coordinated release candidates. Merge after the Pi firmware status producer change.

Verification:
- `bun run lint`
- `bun run test` (86 tests)
- `bun run fmt:check`
- `bun run build`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` (31 tests)

---
Generated by UNKNOWN-MODEL using the Codex harness.