### PR TITLE
chore(release): v1.0.17-rc.8

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2245,7 +2245,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "manafish"
-version = "1.0.17"
+version = "1.0.17-rc.8"
 dependencies = [
  "bytes",
  "dirs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "manafish"
 description = "An app for controlling the Manafish ROV"
-version = "1.0.17"
+version = "1.0.17-rc.8"
 license = "AGPL-3.0-or-later"
 authors = ["Michael Brusegard"]
 edition = "2024"

--- a/src-tauri/com.manafishrov.manafish.metainfo.xml
+++ b/src-tauri/com.manafishrov.manafish.metainfo.xml
@@ -48,6 +48,7 @@
   <content_rating type="oars-1.1" />
 
   <releases>
+    <release version="1.0.17-rc.8" date="2026-08-22" />
     <release version="1.0.17" date="2026-08-06" />
     <release version="1.0.13" date="2026-06-07" />
     <release version="1.0.12" date="2026-06-04" />

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Manafish",
-  "version": "1.0.17",
+  "version": "1.0.17-rc.8",
   "identifier": "com.manafishrov.manafish",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src-yolo/pyproject.toml
+++ b/src-yolo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "manafish"
-version = "1.0.17"
+version = "1.0.17-rc.8"
 description = "An app for controlling the Manafish ROV"
 requires-python = "==3.14.6"
 dependencies = ["ultralytics==8.4.107"]

--- a/src-yolo/uv.lock
+++ b/src-yolo/uv.lock
@@ -267,7 +267,7 @@ wheels = [
 
 [[package]]
 name = "manafish"
-version = "1.0.17"
+version = "1.0.17-rc.8"
 source = { virtual = "." }
 dependencies = [
     { name = "ultralytics" },


### PR DESCRIPTION
Prepare app `v1.0.17-rc.8` with one exact release identity across every package and platform metadata file.

- set the Tauri package, lockfile, and runtime config to `1.0.17-rc.8`
- add the exact release candidate to AppStream metadata
- align the companion YOLO package and lockfile
- validate the canonical tag against every embedded version

## Platform testing

- Linux: frontend production build and complete Rust checks pass locally and in CI.
- Windows and macOS: installer builds run in the tag-triggered release workflow.
- Windows installers remain intentionally unsigned for this release candidate.

## Checklist

- [x] Canonical release identity validated in every declared version file
- [x] Frontend formatting, lint, build, and 86 tests pass
- [x] Rust formatting, Clippy, and 31 tests pass
- [x] No runtime behavior changed in this release commit

---
Generated by UNKNOWN-MODEL using the Codex harness.