### PR TITLE
fix(release): build Windows RCs with NSIS

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -372,7 +372,8 @@ jobs:
         with:
           releaseId: ${{ needs.create-release.outputs.release_id }}
 
-      # Windows: direct downloads own their own updates.
+      # Windows: direct downloads own their own updates. Build only NSIS because
+      # WiX/MSI rejects canonical SemVer prereleases such as `1.0.17-rc.8`.
       - name: Build and upload Windows to draft release
         if: matrix.platform == 'windows-latest'
         uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1
@@ -383,6 +384,7 @@ jobs:
           CMAKE_POLICY_VERSION_MINIMUM: 3.5
         with:
           releaseId: ${{ needs.create-release.outputs.release_id }}
+          args: --bundles nsis
 
       # Linux deb/rpm: package-manager owned, so the in-app updater is
       # compiled out (it can only replace an AppImage in place; touching a


### PR DESCRIPTION
## Summary

- build Windows releases as NSIS installers only
- preserve the canonical `x.y.z-rc.N` app identity in Windows RC artifacts
- keep Tauri updater signing while leaving Windows Authenticode signing disabled

## Why

WiX/MSI rejects canonical SemVer prereleases such as `1.0.17-rc.8`. The application binary builds successfully, but MSI packaging fails before any Windows installer or updater artifact is uploaded. NSIS accepts the canonical version and is already supported by Tauri's release and updater flow.

## Platform testing

- Linux: production build, formatting, lint, and frontend tests pass locally
- Windows: release workflow is expected to prove NSIS packaging on the hosted Windows runner
- macOS: workflow-only change does not alter the macOS build step

## Checklist

- [x] Change is limited to Windows bundle selection
- [x] No Windows certificate or Authenticode dependency was added
- [x] App release identity remains exact and canonical
- [x] Production build passes
- [x] 86 frontend tests pass

---
Generated by UNKNOWN-MODEL using the Codex harness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that Windows prerelease builds use the NSIS installer format because MSI does not support SemVer prereleases.
* **Builds**
  * Windows release builds now explicitly package only the NSIS installer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->