### PR TITLE
chore(release): v1.0.17-rc.9

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2245,7 +2245,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "manafish"
-version = "1.0.17-rc.8"
+version = "1.0.17-rc.9"
 dependencies = [
  "bytes",
  "dirs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "manafish"
 description = "An app for controlling the Manafish ROV"
-version = "1.0.17-rc.8"
+version = "1.0.17-rc.9"
 license = "AGPL-3.0-or-later"
 authors = ["Michael Brusegard"]
 edition = "2024"

--- a/src-tauri/com.manafishrov.manafish.metainfo.xml
+++ b/src-tauri/com.manafishrov.manafish.metainfo.xml
@@ -48,7 +48,7 @@
   <content_rating type="oars-1.1" />
 
   <releases>
-    <release version="1.0.17-rc.8" date="2026-08-22" />
+    <release version="1.0.17-rc.9" date="2026-08-22" />
     <release version="1.0.17" date="2026-08-06" />
     <release version="1.0.13" date="2026-06-07" />
     <release version="1.0.12" date="2026-06-04" />

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Manafish",
-  "version": "1.0.17-rc.8",
+  "version": "1.0.17-rc.9",
   "identifier": "com.manafishrov.manafish",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src-yolo/pyproject.toml
+++ b/src-yolo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "manafish"
-version = "1.0.17-rc.8"
+version = "1.0.17-rc.9"
 description = "An app for controlling the Manafish ROV"
 requires-python = "==3.14.6"
 dependencies = ["ultralytics==8.4.107"]

--- a/src-yolo/uv.lock
+++ b/src-yolo/uv.lock
@@ -267,7 +267,7 @@ wheels = [
 
 [[package]]
 name = "manafish"
-version = "1.0.17-rc.8"
+version = "1.0.17-rc.9"
 source = { virtual = "." }
 dependencies = [
     { name = "ultralytics" },


### PR DESCRIPTION
## Summary

- set every embedded app version to `1.0.17-rc.9`
- preserve the same exact canonical release identity in Tauri, Cargo, AppStream, and the sidecar metadata
- prepare the first complete app RC after switching Windows packaging to NSIS

## Platform testing

- Frontend production build passes
- Frontend formatting and lint pass
- 86 frontend tests pass
- Rust formatting and Clippy pass
- 31 Rust tests pass
- Exact release identity validator passes for `v1.0.17-rc.9`

## Checklist

- [x] All declared app versions match the tag
- [x] RC identity uses canonical `x.y.z-rc.N` format
- [x] Windows release packaging uses NSIS
- [x] No compatibility aliases or normalized RC identities were added

---
Generated by UNKNOWN-MODEL using the Codex harness.
