### PR TITLE
fix(release): build MSI for stable Windows releases

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -372,8 +372,9 @@ jobs:
         with:
           releaseId: ${{ needs.create-release.outputs.release_id }}
 
-      # Windows: direct downloads own their own updates. Build only NSIS because
-      # WiX/MSI rejects canonical SemVer prereleases such as `1.0.17-rc.8`.
+      # Windows: direct downloads own their own updates. WiX/MSI rejects
+      # canonical SemVer prereleases such as `1.0.17-rc.8`, so prereleases use
+      # NSIS only while stable releases publish both installer formats.
       - name: Build and upload Windows to draft release
         if: matrix.platform == 'windows-latest'
         uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1
@@ -384,7 +385,7 @@ jobs:
           CMAKE_POLICY_VERSION_MINIMUM: 3.5
         with:
           releaseId: ${{ needs.create-release.outputs.release_id }}
-          args: --bundles nsis
+          args: ${{ contains(github.ref_name, '-') && '--bundles nsis' || '--bundles nsis,msi' }}
 
       # Linux deb/rpm: package-manager owned, so the in-app updater is
       # compiled out (it can only replace an AppImage in place; touching a

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,6 +14,8 @@ jobs:
   validate-release:
     name: Validate Release Identity
     runs-on: ubuntu-24.04
+    outputs:
+      prerelease: ${{ steps.validate.outputs.prerelease }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -21,9 +23,20 @@ jobs:
           persist-credentials: false
 
       - name: Validate tag and embedded versions
+        id: validate
         env:
           TAG: ${{ github.ref_name }}
-        run: python3 scripts/validate-release-version.py "$TAG"
+        run: |
+          set -euo pipefail
+          python3 scripts/validate-release-version.py "$TAG"
+
+          version="${TAG#v}"
+          version_without_build="${version%%+*}"
+          if [[ "$version_without_build" == *-* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
 
   create-release:
     name: Create Draft Release
@@ -31,6 +44,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       release_id: ${{ steps.create.outputs.release_id }}
+      prerelease: ${{ needs.validate-release.outputs.prerelease }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -46,13 +60,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           TAG: ${{ github.ref_name }}
+          PRERELEASE: ${{ needs.validate-release.outputs.prerelease }}
         run: |
           set -euo pipefail
           tag="$TAG"
           repo="$REPO"
           if ! gh release view "$tag" -R "$repo" >/dev/null 2>&1; then
             args=(--draft --title "$tag" --notes "")
-            if [[ "$tag" == *-* ]]; then
+            if [[ "$PRERELEASE" == "true" ]]; then
               args+=(--prerelease)
             fi
             gh release create "$tag" -R "$repo" "${args[@]}"
@@ -385,7 +400,7 @@ jobs:
           CMAKE_POLICY_VERSION_MINIMUM: 3.5
         with:
           releaseId: ${{ needs.create-release.outputs.release_id }}
-          args: ${{ contains(github.ref_name, '-') && '--bundles nsis' || '--bundles nsis,msi' }}
+          args: ${{ needs.create-release.outputs.prerelease == 'true' && '--bundles nsis' || '--bundles nsis,msi' }}
 
       # Linux deb/rpm: package-manager owned, so the in-app updater is
       # compiled out (it can only replace an AppImage in place; touching a


### PR DESCRIPTION
## Summary

- build Windows prereleases with NSIS only
- build stable Windows releases with both NSIS and MSI
- classify prereleases from the validated SemVer identity, so build metadata cannot change the result
- use the same classification when marking the GitHub release as a prerelease

## Platform Testing

- [ ] macOS
- [ ] Windows
- [x] Linux

- **Potential platform issues:** The MSI branch can only run on Windows CI for the next stable tag. No release is created by this PR.

## Checklist

- [ ] Code compiles (`bun run tauri build`)
- [ ] Tested manually
- [x] No breaking changes to firmware communication

## Verification

- frontend production build, formatting, lint, and 86 tests pass
- Rust formatting, Clippy, and 31 tests pass
- SemVer classification cases cover stable, RC, and hyphenated build metadata
- `actionlint` reports only pre-existing ShellCheck findings outside the changed scripts

---
Generated by UNKNOWN-MODEL using the Codex harness.
