### PR TITLE
chore(release): v1.0.17-rc.10

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2245,7 +2245,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "manafish"
-version = "1.0.17-rc.9"
+version = "1.0.17-rc.10"
 dependencies = [
  "bytes",
  "dirs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "manafish"
 description = "An app for controlling the Manafish ROV"
-version = "1.0.17-rc.9"
+version = "1.0.17-rc.10"
 license = "AGPL-3.0-or-later"
 authors = ["Michael Brusegard"]
 edition = "2024"

--- a/src-tauri/com.manafishrov.manafish.metainfo.xml
+++ b/src-tauri/com.manafishrov.manafish.metainfo.xml
@@ -48,6 +48,7 @@
   <content_rating type="oars-1.1" />
 
   <releases>
+    <release version="1.0.17-rc.10" date="2026-08-25" />
     <release version="1.0.17-rc.9" date="2026-08-22" />
     <release version="1.0.17" date="2026-08-06" />
     <release version="1.0.13" date="2026-06-07" />

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Manafish",
-  "version": "1.0.17-rc.9",
+  "version": "1.0.17-rc.10",
   "identifier": "com.manafishrov.manafish",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src-yolo/pyproject.toml
+++ b/src-yolo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "manafish"
-version = "1.0.17-rc.9"
+version = "1.0.17-rc.10"
 description = "An app for controlling the Manafish ROV"
 requires-python = "==3.14.6"
 dependencies = ["ultralytics==8.4.107"]

--- a/src-yolo/uv.lock
+++ b/src-yolo/uv.lock
@@ -267,7 +267,7 @@ wheels = [
 
 [[package]]
 name = "manafish"
-version = "1.0.17-rc.9"
+version = "1.0.17-rc.10"
 source = { virtual = "." }
 dependencies = [
     { name = "ultralytics" },


### PR DESCRIPTION
Prepare the desktop app release candidate for ROV and installer testing.

This updates every embedded app identity to `1.0.17-rc.10`, including Cargo, Tauri, AppStream, and the auxiliary Python package.

Verification:

- release identity validator
- frontend formatting and lint
- production frontend build
- 91 frontend tests
- Rust formatting and clippy
- 38 Rust tests

No installer or ROV hardware testing has been performed on this release candidate yet.

---
Generated by UNKNOWN-MODEL using the Codex harness.