### PR TITLE
chore(release): v1.0.17-rc.12

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2245,7 +2245,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "manafish"
-version = "1.0.17-rc.11"
+version = "1.0.17-rc.12"
 dependencies = [
  "bytes",
  "dirs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "manafish"
 description = "An app for controlling the Manafish ROV"
-version = "1.0.17-rc.11"
+version = "1.0.17-rc.12"
 license = "AGPL-3.0-or-later"
 authors = ["Michael Brusegard"]
 edition = "2024"

--- a/src-tauri/com.manafishrov.manafish.metainfo.xml
+++ b/src-tauri/com.manafishrov.manafish.metainfo.xml
@@ -48,6 +48,7 @@
   <content_rating type="oars-1.1" />
 
   <releases>
+    <release version="1.0.17-rc.12" date="2026-09-06" />
     <release version="1.0.17-rc.11" date="2026-08-30" />
     <release version="1.0.17-rc.10" date="2026-08-25" />
     <release version="1.0.17-rc.9" date="2026-08-22" />

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Manafish",
-  "version": "1.0.17-rc.11",
+  "version": "1.0.17-rc.12",
   "identifier": "com.manafishrov.manafish",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src-yolo/pyproject.toml
+++ b/src-yolo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "manafish"
-version = "1.0.17-rc.11"
+version = "1.0.17-rc.12"
 description = "An app for controlling the Manafish ROV"
 requires-python = "==3.14.6"
 dependencies = ["ultralytics==8.4.107"]

--- a/src-yolo/uv.lock
+++ b/src-yolo/uv.lock
@@ -267,7 +267,7 @@ wheels = [
 
 [[package]]
 name = "manafish"
-version = "1.0.17-rc.11"
+version = "1.0.17-rc.12"
 source = { virtual = "." }
 dependencies = [
     { name = "ultralytics" },


### PR DESCRIPTION
Prepare the approved `v1.0.17-rc.12` release of #196. Align Cargo, Tauri, AppStream, and sandbox identities; no runtime changes.

The release-identity validator, frontend build, formatting/lint, all-target/all-feature Clippy, 110 frontend tests, and 42 Rust tests pass. The tag-triggered workflow will build the release assets before publication.

---
Generated by gpt-6-astra using the Pi harness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application release version to **1.0.17-rc.12** across all packaged components.
  - Added release metadata dated **September 6, 2026**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->