### PR TITLE
chore(release): v1.0.17-rc.13

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2245,7 +2245,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "manafish"
-version = "1.0.17-rc.12"
+version = "1.0.17-rc.13"
 dependencies = [
  "bytes",
  "dirs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "manafish"
 description = "An app for controlling the Manafish ROV"
-version = "1.0.17-rc.12"
+version = "1.0.17-rc.13"
 license = "AGPL-3.0-or-later"
 authors = ["Michael Brusegard"]
 edition = "2024"

--- a/src-tauri/com.manafishrov.manafish.metainfo.xml
+++ b/src-tauri/com.manafishrov.manafish.metainfo.xml
@@ -48,6 +48,7 @@
   <content_rating type="oars-1.1" />
 
   <releases>
+    <release version="1.0.17-rc.13" date="2026-09-07" />
     <release version="1.0.17-rc.12" date="2026-09-06" />
     <release version="1.0.17-rc.11" date="2026-08-30" />
     <release version="1.0.17-rc.10" date="2026-08-25" />

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Manafish",
-  "version": "1.0.17-rc.12",
+  "version": "1.0.17-rc.13",
   "identifier": "com.manafishrov.manafish",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src-yolo/pyproject.toml
+++ b/src-yolo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "manafish"
-version = "1.0.17-rc.12"
+version = "1.0.17-rc.13"
 description = "An app for controlling the Manafish ROV"
 requires-python = "==3.14.6"
 dependencies = ["ultralytics==8.4.107"]

--- a/src-yolo/uv.lock
+++ b/src-yolo/uv.lock
@@ -267,7 +267,7 @@ wheels = [
 
 [[package]]
 name = "manafish"
-version = "1.0.17-rc.12"
+version = "1.0.17-rc.13"
 source = { virtual = "." }
 dependencies = [
     { name = "ultralytics" },


### PR DESCRIPTION
Prepare app v1.0.17-rc.13 with the changes merged in #200: nullable current-above-idle display, removal of the sensor-layout setting, and the Linux Settings fix from UI 1.5.10. Earlier field diagnostics and log export remain included.

Synchronize all six embedded versions and add the AppStream release entry. No dependency updates are included in this version-only PR.

Frontend build, formatting, type-aware lint, 112 frontend tests, Rust formatting/clippy, 44 Rust tests, and the six-field release-version validator pass. Native Linux Settings and hardware behavior remain manually untested.

Publish/install this app before firmware v1.1.6-rc.10. AM32 v2.21.0-rc.3 must be installed on all eight ESCs using the old Pico before Pico/Pico 2 v1.0.3-rc.7 or a Pi bundle containing it. Current is a reporting-only estimate above idle, not absolute battery current or protection.

---
Generated by gpt-6-astra using the Pi harness.
