### PR TITLE
fix(ci): pin macOS FFmpeg and prepare v1.0.17-rc.14

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -144,8 +144,16 @@ jobs:
       - name: Install macOS dependencies
         if: matrix.platform == 'macos-latest'
         run: |
-          brew install ffmpeg
-          for pkg in ffmpeg $(brew deps ffmpeg); do
+          set -euo pipefail
+          brew install ffmpeg@8
+          export FFMPEG_DIR="$(brew --prefix ffmpeg@8)"
+          export PKG_CONFIG_PATH="${FFMPEG_DIR}/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+          if [[ "$(pkg-config --modversion libavcodec)" != 62.* ]]; then
+            echo "Expected FFmpeg 8 (libavcodec 62)" >&2
+            exit 1
+          fi
+          printf 'FFMPEG_DIR=%s\nPKG_CONFIG_PATH=%s\n' "$FFMPEG_DIR" "$PKG_CONFIG_PATH" >> "$GITHUB_ENV"
+          for pkg in ffmpeg@8 $(brew deps ffmpeg@8); do
             pkg_lib="$(brew --prefix "$pkg")/lib"
             [ -d "$pkg_lib" ] || continue
             for dylib in "$pkg_lib"/*.dylib; do

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,14 @@ and release notes back to the user before doing anything.**
   and creates a **draft** GitHub release. Edit and publish manually.
 - Pre-releases use `vX.Y.Z-rc.N` (or similar) and are auto-marked prerelease.
 
+### macOS FFmpeg
+
+When changing FFmpeg or macOS packaging, keep the Homebrew major, Rust bindings,
+and bundled dylibs compatible. The release workflow selects the versioned keg
+for both discovery and bundling; unversioned Homebrew FFmpeg can advance to an
+unsupported ABI. `scripts/macosFfmpeg.test.ts` exercises that workflow step with
+recording stubs, but a native macOS build is still required to verify compilation.
+
 ### Bundled WebKitGTK (Linux)
 
 Linux packages bundle a custom WebKitGTK built with `ENABLE_WEB_RTC` (distro

--- a/scripts/macosFfmpeg.test.ts
+++ b/scripts/macosFfmpeg.test.ts
@@ -1,0 +1,116 @@
+import { spawnSync } from 'node:child_process';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const EXECUTABLE_MODE = 0o755;
+const NOT_FOUND = -1;
+const folders: string[] = [];
+const stubs = {
+  brew: `case "$*" in
+    'install ffmpeg@8') exit 0 ;;
+    '--prefix ffmpeg@8') printf '%s\\n' "$TEST_FFMPEG_PREFIX" ;;
+    'deps ffmpeg@8') exit 0 ;;
+    *) echo 'Unexpected unpinned Homebrew selection' >&2; exit 1 ;;
+  esac`,
+  'pkg-config': `test "$*" = '--modversion libavcodec' || exit 1
+    test "$FFMPEG_DIR" = "$TEST_FFMPEG_PREFIX" || exit 1
+    case "$PKG_CONFIG_PATH" in "$TEST_FFMPEG_PREFIX/lib/pkgconfig":*) ;; *) exit 1 ;; esac
+    printf '%s\\n' "$TEST_CODEC_VERSION"`,
+  install_name_tool: 'exit 0',
+  otool: 'exit 0',
+};
+
+type Fixture = { folder: string; bin: string; prefix: string; environmentFile: string };
+
+const setupStep = (): string => {
+  const workflow = readFileSync(
+    new URL('../.github/workflows/build.yaml', import.meta.url),
+    'utf8',
+  );
+  const start = workflow.indexOf('      - name: Install macOS dependencies');
+  const end = workflow.indexOf('      - name: Install Linux dependencies', start);
+  if (start === NOT_FOUND || end === NOT_FOUND) {
+    throw new Error('Missing macOS dependency setup');
+  }
+  const [, step = ''] = workflow.slice(start, end).split('        run: |\n');
+  if (step.length === 0) {
+    throw new Error('Missing macOS setup script');
+  }
+  return step.replaceAll(/^ {10}/gm, '');
+};
+
+const writeStubs = (bin: string): void => {
+  for (const [name, body] of Object.entries(stubs)) {
+    const executable = path.join(bin, name);
+    writeFileSync(executable, `#!/bin/sh\n${body}\n`);
+    chmodSync(executable, EXECUTABLE_MODE);
+  }
+};
+
+const createFixture = (): Fixture => {
+  const folder = mkdtempSync(path.join(tmpdir(), 'manafish-ffmpeg-'));
+  folders.push(folder);
+  const fixture = {
+    folder,
+    bin: path.join(folder, 'bin'),
+    prefix: path.join(folder, 'ffmpeg8'),
+    environmentFile: path.join(folder, 'github-env'),
+  };
+  for (const directory of [
+    fixture.bin,
+    path.join(fixture.prefix, 'lib', 'pkgconfig'),
+    path.join(folder, 'src-tauri'),
+  ]) {
+    mkdirSync(directory, { recursive: true });
+  }
+  writeFileSync(fixture.environmentFile, '');
+  writeFileSync(path.join(fixture.prefix, 'lib', 'libavcodec.62.dylib'), 'fixture');
+  writeStubs(fixture.bin);
+  return fixture;
+};
+
+const runSetup = (codecVersion: string): { status: number | null; stderr: string; env: string } => {
+  const fixture = createFixture();
+  const result = spawnSync('bash', ['-eu', '-c', setupStep()], {
+    cwd: fixture.folder,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: `${fixture.bin}:${process.env['PATH'] ?? ''}`,
+      GITHUB_ENV: fixture.environmentFile,
+      FFMPEG_DIR: '/unversioned/ffmpeg9',
+      PKG_CONFIG_PATH: '/unversioned/ffmpeg9/lib/pkgconfig',
+      TEST_FFMPEG_PREFIX: fixture.prefix,
+      TEST_CODEC_VERSION: codecVersion,
+    },
+  });
+  return {
+    status: result.status,
+    stderr: result.stderr,
+    env: readFileSync(fixture.environmentFile, 'utf8'),
+  };
+};
+
+afterEach(() => {
+  for (const folder of folders.splice(0)) {
+    rmSync(folder, { recursive: true, force: true });
+  }
+});
+
+describe.skipIf(process.platform === 'win32')('macOS release FFmpeg selection', () => {
+  it('selects the FFmpeg 8 keg for discovery and bundling over an inherited FFmpeg 9', () => {
+    const result = runSetup('62.28.100');
+    expect(result.stderr).toBe('');
+    expect(result.status).toBe(0);
+    expect(result.env).toContain('/ffmpeg8\n');
+    expect(result.env).toContain('/ffmpeg8/lib/pkgconfig:/unversioned/ffmpeg9/lib/pkgconfig');
+  });
+
+  it('rejects an incompatible libavcodec before packaging', () => {
+    const result = runSetup('63.1.101');
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('Expected FFmpeg 8');
+  });
+});

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2245,7 +2245,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "manafish"
-version = "1.0.17-rc.13"
+version = "1.0.17-rc.14"
 dependencies = [
  "bytes",
  "dirs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "manafish"
 description = "An app for controlling the Manafish ROV"
-version = "1.0.17-rc.13"
+version = "1.0.17-rc.14"
 license = "AGPL-3.0-or-later"
 authors = ["Michael Brusegard"]
 edition = "2024"

--- a/src-tauri/com.manafishrov.manafish.metainfo.xml
+++ b/src-tauri/com.manafishrov.manafish.metainfo.xml
@@ -48,6 +48,7 @@
   <content_rating type="oars-1.1" />
 
   <releases>
+    <release version="1.0.17-rc.14" date="2026-09-07" />
     <release version="1.0.17-rc.13" date="2026-09-07" />
     <release version="1.0.17-rc.12" date="2026-09-06" />
     <release version="1.0.17-rc.11" date="2026-08-30" />

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Manafish",
-  "version": "1.0.17-rc.13",
+  "version": "1.0.17-rc.14",
   "identifier": "com.manafishrov.manafish",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src-yolo/pyproject.toml
+++ b/src-yolo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "manafish"
-version = "1.0.17-rc.13"
+version = "1.0.17-rc.14"
 description = "An app for controlling the Manafish ROV"
 requires-python = "==3.14.6"
 dependencies = ["ultralytics==8.4.107"]

--- a/src-yolo/uv.lock
+++ b/src-yolo/uv.lock
@@ -267,7 +267,7 @@ wheels = [
 
 [[package]]
 name = "manafish"
-version = "1.0.17-rc.13"
+version = "1.0.17-rc.14"
 source = { virtual = "." }
 dependencies = [
     { name = "ultralytics" },

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -6,5 +6,5 @@
     "allowImportingTsExtensions": false,
     "noEmit": false
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "scripts/**/*.test.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,6 @@ export default defineConfig({
     },
   },
   test: {
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'scripts/**/*.test.ts'],
   },
 });


### PR DESCRIPTION
Fix the macOS release build and prepare app v1.0.17-rc.14 without moving RC13's tag.

RC13's macOS runner installed Homebrew FFmpeg 9.0.1, then failed compiling `ffmpeg-next` 8.1.0 against removed fields and new enum variants. Select `ffmpeg@8` explicitly for installation, headers/library discovery, and bundled dylibs. Export the keg's `FFMPEG_DIR` and `PKG_CONFIG_PATH`, and reject a libavcodec major other than 62 before packaging. Rust dependencies and other platforms are unchanged.

Two regressions execute the actual workflow step with shell stubs: they failed on the old unversioned setup and pass with the fix. They check that an inherited FFmpeg 9 path cannot override the versioned keg and that an incompatible ABI is rejected. Script tests use the existing Node-capable build TypeScript project rather than adding Node globals to frontend code; Windows skips these shell-specific tests.

All 114 frontend/workflow tests, 44 Rust tests, frontend build, formatting, type-aware lint, clippy, and the six-field release-version validator pass. The native macOS release build remains the final integration check; the stub tests do not prove native compilation.

RC14 retains the MCU current-above-idle display, removed sensor-layout selector, UI 1.5.10 Linux Settings fix, and earlier diagnostics/log export. Publish the complete app before the already-built firmware v1.1.6-rc.10. Firmware artifacts/signatures are verified and remain unpublished. ESC-first installation and hardware-validation requirements are unchanged.

---
Generated by gpt-6-astra using the Pi harness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Updated the application to version 1.0.17-rc.14.

- **Bug Fixes**
  - macOS release builds now consistently use FFmpeg 8 and verify compatibility before packaging.

- **Tests**
  - Added automated coverage for FFmpeg version selection, environment configuration, and incompatible-version failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->