### PR TITLE
fix(ci): refresh homebrew and validate native ffmpeg before tagging

### DIFF
--- a/.github/scripts/setup-macos-ffmpeg.sh
+++ b/.github/scripts/setup-macos-ffmpeg.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Runner images can disable automatic updates and retain an older formula index.
+brew update
+brew install ffmpeg@8
+export FFMPEG_DIR="$(brew --prefix ffmpeg@8)"
+export PKG_CONFIG_PATH="${FFMPEG_DIR}/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+if [[ "$(pkg-config --modversion libavcodec)" != 62.* ]]; then
+  echo "Expected FFmpeg 8 (libavcodec 62)" >&2
+  exit 1
+fi
+printf 'FFMPEG_DIR=%s\nPKG_CONFIG_PATH=%s\n' "$FFMPEG_DIR" "$PKG_CONFIG_PATH" >> "$GITHUB_ENV"
+for pkg in ffmpeg@8 $(brew deps ffmpeg@8); do
+  pkg_lib="$(brew --prefix "$pkg")/lib"
+  [ -d "$pkg_lib" ] || continue
+  for dylib in "$pkg_lib"/*.dylib; do
+    [ -L "$dylib" ] && continue
+    [ -f "$dylib" ] || continue
+    install_name_tool -id "@rpath/$(basename "$dylib")" "$dylib"
+    for dep in $(otool -L "$dylib" | grep /opt/homebrew | awk '{print $1}'); do
+      install_name_tool -change "$dep" "@rpath/$(basename "$dep")" "$dylib"
+    done
+  done
+  cp -P "$pkg_lib"/*.dylib src-tauri/ 2>/dev/null || true
+done
+DYLIBS_JSON=$(ls src-tauri/*.dylib | sed 's|src-tauri/|./|' | sed 's|^|"|' | sed 's|$|"|' | tr '\n' ',' | sed 's/,$//')
+bun -e "console.log(JSON.stringify({bundle: {macOS: {frameworks: [$DYLIBS_JSON]}}}))" > src-tauri/tauri.macos.conf.json

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -143,31 +143,7 @@ jobs:
 
       - name: Install macOS dependencies
         if: matrix.platform == 'macos-latest'
-        run: |
-          set -euo pipefail
-          brew install ffmpeg@8
-          export FFMPEG_DIR="$(brew --prefix ffmpeg@8)"
-          export PKG_CONFIG_PATH="${FFMPEG_DIR}/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
-          if [[ "$(pkg-config --modversion libavcodec)" != 62.* ]]; then
-            echo "Expected FFmpeg 8 (libavcodec 62)" >&2
-            exit 1
-          fi
-          printf 'FFMPEG_DIR=%s\nPKG_CONFIG_PATH=%s\n' "$FFMPEG_DIR" "$PKG_CONFIG_PATH" >> "$GITHUB_ENV"
-          for pkg in ffmpeg@8 $(brew deps ffmpeg@8); do
-            pkg_lib="$(brew --prefix "$pkg")/lib"
-            [ -d "$pkg_lib" ] || continue
-            for dylib in "$pkg_lib"/*.dylib; do
-              [ -L "$dylib" ] && continue
-              [ -f "$dylib" ] || continue
-              install_name_tool -id "@rpath/$(basename "$dylib")" "$dylib"
-              for dep in $(otool -L "$dylib" | grep /opt/homebrew | awk '{print $1}'); do
-                install_name_tool -change "$dep" "@rpath/$(basename "$dep")" "$dylib"
-              done
-            done
-            cp -P "$pkg_lib"/*.dylib src-tauri/ 2>/dev/null || true
-          done
-          DYLIBS_JSON=$(ls src-tauri/*.dylib | sed 's|src-tauri/|./|' | sed 's|^|"|' | sed 's|$|"|' | tr '\n' ',' | sed 's/,$//')
-          bun -e "console.log(JSON.stringify({bundle: {macOS: {frameworks: [$DYLIBS_JSON]}}}))" > src-tauri/tauri.macos.conf.json
+        run: bash .github/scripts/setup-macos-ffmpeg.sh
 
       - name: Install Linux dependencies
         if: matrix.platform == 'ubuntu-24.04' || matrix.platform == 'ubuntu-24.04-arm'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,14 +97,6 @@ jobs:
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           toolchain: stable
-      - name: Inspect metadata before refresh
-        run: |
-          brew --version
-          if brew info --json=v2 ffmpeg@8 > "$RUNNER_TEMP/ffmpeg-before.json"; then
-            echo '[DEBUG-mac-index] FFmpeg 8 available before refresh'
-          else
-            echo '[DEBUG-mac-index] FFmpeg 8 unavailable before refresh'
-          fi
       - name: Install and bundle macOS FFmpeg
         run: bash .github/scripts/setup-macos-ffmpeg.sh
       - name: Compile native FFmpeg bindings

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,18 +84,47 @@ jobs:
       - name: Build
         run: cargo build --all-targets --all-features
 
+  check-macos-ffmpeg:
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: latest
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+      - name: Inspect metadata before refresh
+        run: |
+          brew --version
+          if brew info --json=v2 ffmpeg@8 > "$RUNNER_TEMP/ffmpeg-before.json"; then
+            echo '[DEBUG-mac-index] FFmpeg 8 available before refresh'
+          else
+            echo '[DEBUG-mac-index] FFmpeg 8 unavailable before refresh'
+          fi
+      - name: Install and bundle macOS FFmpeg
+        run: bash .github/scripts/setup-macos-ffmpeg.sh
+      - name: Compile native FFmpeg bindings
+        run: cargo check --locked --manifest-path src-tauri/Cargo.toml -p ffmpeg-next
+
   ci:
     name: ci
     if: always()
     needs:
       - check-frontend
       - check-backend
+      - check-macos-ffmpeg
     runs-on: ubuntu-latest
     steps:
       - name: Require all checks
         env:
           FRONTEND_RESULT: ${{ needs.check-frontend.result }}
           BACKEND_RESULT: ${{ needs.check-backend.result }}
+          MACOS_FFMPEG_RESULT: ${{ needs.check-macos-ffmpeg.result }}
         run: |
           test "$FRONTEND_RESULT" = success
           test "$BACKEND_RESULT" = success
+          test "$MACOS_FFMPEG_RESULT" = success

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,10 +75,13 @@ and release notes back to the user before doing anything.**
 ### macOS FFmpeg
 
 When changing FFmpeg or macOS packaging, keep the Homebrew major, Rust bindings,
-and bundled dylibs compatible. The release workflow selects the versioned keg
-for both discovery and bundling; unversioned Homebrew FFmpeg can advance to an
-unsupported ABI. `scripts/macosFfmpeg.test.ts` exercises that workflow step with
-recording stubs, but a native macOS build is still required to verify compilation.
+and bundled dylibs compatible. CI and releases share
+`.github/scripts/setup-macos-ffmpeg.sh`, which refreshes Homebrew metadata and
+selects the versioned keg for discovery and bundling. Unversioned Homebrew
+FFmpeg can advance to an unsupported ABI. `scripts/macosFfmpeg.test.ts` covers
+setup behavior with stubs; `check-macos-ffmpeg` runs the script and compiles the
+Rust bindings natively. Require that check before tagging a macOS build change;
+a complete release build is still needed to validate application packaging.
 
 ### Bundled WebKitGTK (Linux)
 

--- a/scripts/macosFfmpeg.test.ts
+++ b/scripts/macosFfmpeg.test.ts
@@ -5,11 +5,11 @@ import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
 const EXECUTABLE_MODE = 0o755;
-const NOT_FOUND = -1;
 const folders: string[] = [];
 const stubs = {
   brew: `case "$*" in
-    'install ffmpeg@8') exit 0 ;;
+    'update') touch "$TEST_FFMPEG_PREFIX/refreshed" ;;
+    'install ffmpeg@8') test -f "$TEST_FFMPEG_PREFIX/refreshed" || { echo 'No available formula ffmpeg@8 in stale metadata' >&2; exit 1; } ;;
     '--prefix ffmpeg@8') printf '%s\\n' "$TEST_FFMPEG_PREFIX" ;;
     'deps ffmpeg@8') exit 0 ;;
     *) echo 'Unexpected unpinned Homebrew selection' >&2; exit 1 ;;
@@ -24,22 +24,8 @@ const stubs = {
 
 type Fixture = { folder: string; bin: string; prefix: string; environmentFile: string };
 
-const setupStep = (): string => {
-  const workflow = readFileSync(
-    new URL('../.github/workflows/build.yaml', import.meta.url),
-    'utf8',
-  );
-  const start = workflow.indexOf('      - name: Install macOS dependencies');
-  const end = workflow.indexOf('      - name: Install Linux dependencies', start);
-  if (start === NOT_FOUND || end === NOT_FOUND) {
-    throw new Error('Missing macOS dependency setup');
-  }
-  const [, step = ''] = workflow.slice(start, end).split('        run: |\n');
-  if (step.length === 0) {
-    throw new Error('Missing macOS setup script');
-  }
-  return step.replaceAll(/^ {10}/gm, '');
-};
+const setupStep = (): string =>
+  readFileSync(new URL('../.github/scripts/setup-macos-ffmpeg.sh', import.meta.url), 'utf8');
 
 const writeStubs = (bin: string): void => {
   for (const [name, body] of Object.entries(stubs)) {
@@ -99,8 +85,16 @@ afterEach(() => {
   }
 });
 
+it.each(['build', 'ci'])('%s workflow uses the tested macOS setup script', (workflow) => {
+  const source = readFileSync(
+    new URL(`../.github/workflows/${workflow}.yaml`, import.meta.url),
+    'utf8',
+  );
+  expect(source).toContain('run: bash .github/scripts/setup-macos-ffmpeg.sh');
+});
+
 describe.skipIf(process.platform === 'win32')('macOS release FFmpeg selection', () => {
-  it('selects the FFmpeg 8 keg for discovery and bundling over an inherited FFmpeg 9', () => {
+  it('refreshes stale metadata and selects FFmpeg 8 over an inherited FFmpeg 9', () => {
     const result = runSetup('62.28.100');
     expect(result.stderr).toBe('');
     expect(result.status).toBe(0);


### PR DESCRIPTION
Validate macOS FFmpeg setup before another release tag. RC14's runner could not find `ffmpeg@8`, even though the current public formula API and signed formula index contain version 8.1.2.

Extract the existing dependency setup into a shared script and explicitly run `brew update` before installation. CI now runs the same installation/bundling script on macOS and compiles `ffmpeg-next` against the selected native libraries. The aggregate CI check requires this job. No app versions, Rust dependencies, or runtime behavior change.

Native CI installed/bundled FFmpeg 8.1.2 and successfully compiled `ffmpeg-next` (job 101807955476). The probe found the formula already available before refresh on this runner, so it does not establish the cause of RC14's earlier lookup failure. Explicit refresh avoids relying on an inherited formula index; the native CI gate verifies installation and API compatibility. The temporary probe has been removed.

Local frontend build, formatting, type-aware lint, clippy, 116 frontend/workflow tests, 44 Rust tests, and shell syntax checks pass. The stale-metadata fixture failed before adding the refresh and passes afterward. The extracted shell matches the old release step except for that refresh. Tests also assert that CI and release workflows invoke the shared script.

Require green exact-head CI after probe removal before merging. Do not move the RC13/RC14 tags or publish incomplete artifacts. Firmware RC10 stays unpublished until a complete compatible app release is ready.

---
Generated by gpt-6-astra using the Pi harness.
