### PR TITLE
chore(release): v1.0.17-rc.15

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2245,7 +2245,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "manafish"
-version = "1.0.17-rc.14"
+version = "1.0.17-rc.15"
 dependencies = [
  "bytes",
  "dirs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "manafish"
 description = "An app for controlling the Manafish ROV"
-version = "1.0.17-rc.14"
+version = "1.0.17-rc.15"
 license = "AGPL-3.0-or-later"
 authors = ["Michael Brusegard"]
 edition = "2024"

--- a/src-tauri/com.manafishrov.manafish.metainfo.xml
+++ b/src-tauri/com.manafishrov.manafish.metainfo.xml
@@ -48,6 +48,7 @@
   <content_rating type="oars-1.1" />
 
   <releases>
+    <release version="1.0.17-rc.15" date="2026-09-07" />
     <release version="1.0.17-rc.14" date="2026-09-07" />
     <release version="1.0.17-rc.13" date="2026-09-07" />
     <release version="1.0.17-rc.12" date="2026-09-06" />

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Manafish",
-  "version": "1.0.17-rc.14",
+  "version": "1.0.17-rc.15",
   "identifier": "com.manafishrov.manafish",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src-yolo/pyproject.toml
+++ b/src-yolo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "manafish"
-version = "1.0.17-rc.14"
+version = "1.0.17-rc.15"
 description = "An app for controlling the Manafish ROV"
 requires-python = "==3.14.6"
 dependencies = ["ultralytics==8.4.107"]

--- a/src-yolo/uv.lock
+++ b/src-yolo/uv.lock
@@ -267,7 +267,7 @@ wheels = [
 
 [[package]]
 name = "manafish"
-version = "1.0.17-rc.14"
+version = "1.0.17-rc.15"
 source = { virtual = "." }
 dependencies = [
     { name = "ultralytics" },


### PR DESCRIPTION
Prepare the approved app v1.0.17-rc.15 release. This changes only the six embedded version fields; no dependencies or runtime code change.

Includes the merged MCU current-above-idle display, removed sensor-layout selector, UI 1.5.10 Linux Settings fix, field diagnostics/log export, and macOS FFmpeg 8 discovery/bundling. Homebrew metadata refresh and the shared native CI check are included from #203; installation, bundling, and binding compilation passed on macOS before this version bump.

Validation: frontend build, formatting, type-aware lint, 116 frontend/workflow tests, Rust formatting/clippy, 44 Rust tests, and the six-field release-version validator pass. Full platform packaging and artifact/signature verification still gate publication.

Retain RC13/RC14 tags unchanged and leave their incomplete drafts unpublished. Publish the verified app first, then the unchanged, already-verified firmware v1.1.6-rc.10. Field installation still requires all eight AM32 RC3 ESCs using the old Pico before installing MCU RC7 or the Pi bundle. No hardware flashing or deployment is included.

---
Generated by gpt-6-astra using the Pi harness.
