### PR TITLE
feat(settings): cancel thruster test on Escape

### DIFF
--- a/messages/en-gb.json
+++ b/messages/en-gb.json
@@ -483,6 +483,7 @@
   "toasts_failed_to_set_config_reverted": "Failed to set config. Changes reverted.",
   "toasts_failed_to_start_recording": "Failed to start recording",
   "toasts_failed_to_start_thruster_test": "Failed to start thruster test",
+  "toasts_failed_to_cancel_thruster_test": "Failed to cancel thruster test",
   "toasts_app_config_parse_failed_using_default": "Failed to parse app config, using default config instead",
   "toasts_app_config_set_success": "Config set successfully",
   "toasts_recording_converting_to_mp4": "Converting recording to MP4...",

--- a/src/features/settings/forms/calibration/constants.ts
+++ b/src/features/settings/forms/calibration/constants.ts
@@ -8,6 +8,10 @@ const ONE = Number('1');
 const DECIMAL_RADIX = Number('10');
 const DECIMAL_PRECISION_FACTOR = Number('100');
 const THRUSTER_TEST_TIMEOUT_MS = Number('2000');
+// Mirrors THRUSTER_TEST_DURATION_SECONDS in the firmware repo; the firmware
+// auto-stops the test after this long, so the frontend stops treating it as
+// cancellable at the same point instead of sending a stale cancel request.
+const THRUSTER_TEST_DURATION_MS = Number('10000');
 const ALLOCATION_FIELD_STEP = Number('0.01');
 const DEADZONE_FIELD_STEP = Number('0.01');
 const DEADZONE_THRESHOLD = Number('0.2');
@@ -86,6 +90,7 @@ export {
   THRUSTER_7,
   THRUSTER_COLUMNS,
   THRUSTER_INDICES,
+  THRUSTER_TEST_DURATION_MS,
   THRUSTER_TEST_TIMEOUT_MS,
   ZERO,
 };

--- a/src/features/settings/forms/calibration/index.tsx
+++ b/src/features/settings/forms/calibration/index.tsx
@@ -37,6 +37,7 @@ import {
   THRUSTER_7,
   THRUSTER_COLUMNS,
   THRUSTER_INDICES,
+  THRUSTER_TEST_DURATION_MS,
   THRUSTER_TEST_TIMEOUT_MS,
   ZERO,
 } from './constants';
@@ -176,8 +177,11 @@ const submitCalibrationForm = (value: FormValues): Promise<void> => {
   return setRovConfig({ thrusterPinSetup, thrusterAllocation, nullspaceVectors });
 };
 
+type ActiveTestIndexSetter = (setter: (previous: number | null) => number | null) => number | null;
+
 const testThruster = (
   setDisabled: (setter: (previous: boolean[]) => boolean[]) => boolean[],
+  setActiveTestIndex: ActiveTestIndexSetter,
   index: number,
 ): void => {
   setDisabled((previous) => {
@@ -185,10 +189,17 @@ const testThruster = (
     next[index] = true;
     return next;
   });
+  setActiveTestIndex(() => index);
   invoke('start_thruster_test', { payload: index })
+    .then((): void => {
+      setTimeout(() => {
+        setActiveTestIndex((previous) => (previous === index ? null : previous));
+      }, THRUSTER_TEST_DURATION_MS);
+    })
     .catch((error: unknown): void => {
       logError('Failed to start thruster test:', error);
       toast.create({ title: m.toasts_failed_to_start_thruster_test(), type: 'error' });
+      setActiveTestIndex((previous) => (previous === index ? null : previous));
     })
     .finally((): void => {
       setTimeout(() => {
@@ -199,6 +210,46 @@ const testThruster = (
         });
       }, THRUSTER_TEST_TIMEOUT_MS);
     });
+};
+
+const cancelActiveThrusterTest = (
+  activeTestIndex: () => number | null,
+  setActiveTestIndex: ActiveTestIndexSetter,
+  setDisabled: (setter: (previous: boolean[]) => boolean[]) => boolean[],
+): void => {
+  const index = activeTestIndex();
+  if (index === null) {
+    return;
+  }
+  setActiveTestIndex((previous) => (previous === index ? null : previous));
+  setDisabled((previous) => {
+    const next = [...previous];
+    next[index] = false;
+    return next;
+  });
+  invoke('cancel_thruster_test', { payload: index }).catch((error: unknown): void => {
+    logError('Failed to cancel thruster test:', error);
+    toast.create({ title: m.toasts_failed_to_cancel_thruster_test(), type: 'error' });
+  });
+};
+
+const useThrusterTestEscapeKeybind = (
+  activeTestIndex: () => number | null,
+  setActiveTestIndex: ActiveTestIndexSetter,
+  setDisabled: (setter: (previous: boolean[]) => boolean[]) => boolean[],
+): void => {
+  onMount(() => {
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key !== 'Escape') {
+        return;
+      }
+      cancelActiveThrusterTest(activeTestIndex, setActiveTestIndex, setDisabled);
+    };
+    globalThis.addEventListener('keydown', handleKeyDown);
+    onCleanup(() => {
+      globalThis.removeEventListener('keydown', handleKeyDown);
+    });
+  });
 };
 
 const applyPresetToForm = (
@@ -232,6 +283,7 @@ const resetAllocationInForm = (
 export const Calibration: Component = (): JSXElement => {
   const defaultDisabled = Array.from({ length: PIN_NUMBERS.length }, () => false);
   const [testDisabled, setTestDisabled] = createSignal(defaultDisabled);
+  const [activeTestIndex, setActiveTestIndex] = createSignal<number | null>(null);
   const form = useAppForm(() => ({
     validators: { onChange: formSchema, onSubmit: formSchema },
     defaultValues: createCalibrationFormValues(),
@@ -240,6 +292,8 @@ export const Calibration: Component = (): JSXElement => {
         form.reset(value);
       }),
   }));
+
+  useThrusterTestEscapeKeybind(activeTestIndex, setActiveTestIndex, setTestDisabled);
 
   return (
     <CalibrationFormLayout
@@ -252,7 +306,7 @@ export const Calibration: Component = (): JSXElement => {
       zeroValue={ZERO}
       testDisabled={testDisabled}
       onTestThruster={(index): void => {
-        testThruster(setTestDisabled, index);
+        testThruster(setTestDisabled, setActiveTestIndex, index);
       }}
       onApplyPreset={(presetRows): void => {
         applyPresetToForm(form, presetRows);


### PR DESCRIPTION
## Summary
- Track which thruster's test is currently active (a running test lasts up to 10s server-side, even though the Test button itself only stays disabled for 2s as a click-debounce).
- Pressing `Escape` while on the calibration tab now cancels the active thruster test via the existing `cancel_thruster_test` Tauri command (already implemented in `src-tauri`/firmware, previously only reachable through the toast's own Cancel action).
- The active-test flag auto-clears once the firmware's own test duration elapses, so a later stray `Escape` doesn't send a redundant cancel and stomp on the "completed" toast with a "cancelled" one.
- Added a `toasts_failed_to_cancel_thruster_test` message for the (existing) error-toast pattern used elsewhere in this file.

## Why this is safe
- No backend changes: `cancel_thruster_test` was already wired end-to-end (Tauri command → websocket → firmware), just never invoked from the frontend outside the toast action.
- The keydown listener is registered with `onMount`/`onCleanup` scoped to the `Calibration` component, so it's only live while the calibration tab is mounted, and is a no-op whenever no test is active.
- Existing debounce/disable timing for the Test button is untouched.

## Test plan
- [ ] `bun run lint` / `bun run fmt:check` / `bun run test` (I don't have a JS runtime available in this sandbox to run these — please confirm CI is green)
- [ ] Manually: open Settings → ROV → Calibration, click Test on a thruster, press Escape, confirm the motor stops immediately and the toast shows "Thruster test cancelled"
- [ ] Manually: click Test, let it run past 2s (button re-enables) but before 10s, press Escape, confirm it still cancels
- [ ] Manually: let a test finish naturally, then press Escape, confirm no toast/command fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)